### PR TITLE
Transaction support

### DIFF
--- a/backend/src/AppServer.hs
+++ b/backend/src/AppServer.hs
@@ -1,14 +1,16 @@
 module AppServer where
 
 import Api (Api)
+import Data.Pool (withResource)
 import Data.Time (UTCTime)
 import Data.Time.Clock (getCurrentTime)
 import Data.Validation (Validation (..))
 import Database (insertGameReport, insertPlayerIfNotExists)
+import Database.SQLite.Simple (withTransaction)
 import Servant (ServerError (errBody), ServerT, throwError)
 import Servant.Server (err422)
 import Types.Api (GameReport (..))
-import Types.App (AppM)
+import Types.App (AppM, Env (..))
 import Types.DataField (PlayerId)
 import Types.Database (ReadProcessedGameReport (..), WriteProcessedGameReport (..))
 import Validation (validateReport)
@@ -44,10 +46,12 @@ submitReportHandler :: GameReport -> AppM ReadProcessedGameReport
 submitReportHandler r = case validateReport r of
   Failure errors -> throwError $ err422 {errBody = show errors}
   Success report -> do
-    winnerId <- insertPlayerIfNotExists report.winner
-    loserId <- insertPlayerIfNotExists report.loser
-    now <- liftIO getCurrentTime
-    insertGameReport $ processReport now winnerId loserId report
+    env <- ask
+    liftIO . withResource env.dbPool $ \conn -> withTransaction conn $ do
+      winnerId <- insertPlayerIfNotExists conn report.winner
+      loserId <- insertPlayerIfNotExists conn report.loser
+      now <- liftIO getCurrentTime
+      insertGameReport conn $ processReport now winnerId loserId report
 
 server :: ServerT Api AppM
 server = submitReportHandler


### PR DESCRIPTION
Change the monad context of the database helpers from `AppM` to just `IO`. This means we have to pass the connection explicitly, but makes it possible to group (what are now) IO actions into a single database transaction. We want our handlers to be able to do this, since they are frequently going to be making several queries which should either succeed or fail as a group.

Key new function is from `sqlite-simple` library:
> `withTransaction :: Connection -> IO a -> IO a`
Run an IO action inside a SQL transaction started with BEGIN TRANSACTION. If the action throws any kind of an exception, the transaction will be rolled back with ROLLBACK TRANSACTION. Otherwise the results are committed with COMMIT TRANSACTION.

Note: I suspect (but did not try) that we could keep the database functions inside `AppM` if we changed them from returning "a value embedded in `AppM`" to returning "an `IO` action that yields a value, embedded in `AppM`. So the database functions return the IO actions, and those get composed into a transaction in the handler layer. This sounds a little annoying to deal with even if it works, so I advocate for doing it this way until we have a good reason to need more.