### PR TITLE
Use nodenext for tsconfig module resolution

### DIFF
--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "target": "esnext",
-        "module": "esnext",
+        "module": "nodenext",
         "esModuleInterop": true,
         "forceConsistentCasingInFileNames": true,
         "strict": true,
@@ -9,7 +9,7 @@
         "jsx": "react",
         "allowJs": false,
         "outDir": "./dist",
-        "moduleResolution": "bundler"
+        "moduleResolution": "nodenext"
     },
     "include": ["src/**/*"]
 }


### PR DESCRIPTION
I don't know the pros and cons of different module resolution strategies, but I noticed that with `bundler` TS doesn't throw a compile-time error when I've accidentally used a module in a file without importing it first, and changing to `nodenext` fixes that (and the accompanying change of `module` from `esnext` to `nodenext` was because TS told me I had to). Any opinion or just merge?