### PR TITLE
Submitting a report modifies Elo

### DIFF
--- a/backend/.vscode/settings.json
+++ b/backend/.vscode/settings.json
@@ -7,6 +7,7 @@
         "Edoras",
         "Erebor",
         "Ered",
+        "fmap",
         "fpmv",
         "fprv",
         "Lorien",

--- a/backend/src/Api.hs
+++ b/backend/src/Api.hs
@@ -1,10 +1,9 @@
 module Api where
 
 import Servant (JSON, Post, ReqBody, (:>))
-import Types.Api (GameReport)
-import Types.Database (ReadProcessedGameReport)
+import Types.Api (GameReport, SubmitGameReportResponse)
 
-type SubmitReportAPI = "submitReport" :> ReqBody '[JSON] GameReport :> Post '[JSON] ReadProcessedGameReport
+type SubmitReportAPI = "submitReport" :> ReqBody '[JSON] GameReport :> Post '[JSON] SubmitGameReportResponse
 
 submitReportAPI :: Proxy SubmitReportAPI
 submitReportAPI = Proxy

--- a/backend/src/AppServer.hs
+++ b/backend/src/AppServer.hs
@@ -1,38 +1,98 @@
 module AppServer where
 
 import Api (Api)
+import Data.IntMap.Strict qualified as Map
 import Data.Pool (withResource)
-import Data.Time (UTCTime)
 import Data.Time.Clock (getCurrentTime)
 import Data.Validation (Validation (..))
-import Database (insertGameReport, insertPlayerIfNotExists)
+import Database (getLatestRating, insertGameReport, insertPlayerIfNotExists, insertRatingChange)
 import Database.SQLite.Simple (withTransaction)
 import Servant (ServerError (errBody), ServerT, throwError)
 import Servant.Server (err422)
-import Types.Api (GameReport (..))
+import Types.Api (GameReport (..), SubmitGameReportResponse (..))
 import Types.App (AppM, Env (..))
-import Types.DataField (PlayerId)
-import Types.Database (ReadProcessedGameReport (..), WriteProcessedGameReport (..))
+import Types.DataField (Rating, Side (..))
+import Types.Database (ReadProcessedGameReport (..), WriteProcessedGameReport (..), WriteRatingChange (..))
 import Validation (validateReport)
 
-processReport :: UTCTime -> PlayerId -> PlayerId -> GameReport -> WriteProcessedGameReport
-processReport timestamp winnerId loserId (GameReport {..}) =
-  WriteProcessedGameReport
-    { winnerRatingAfter = 0, -- TODO
-      loserRatingAfter = 0, -- TODO
-      ..
-    }
+defaultRating :: Rating
+defaultRating = 500
 
-submitReportHandler :: GameReport -> AppM ReadProcessedGameReport
+ratingThresholds :: IntMap (Rating, Rating)
+ratingThresholds =
+  fromList
+    [ (10, (16, 16)),
+      (33, (15, 17)),
+      (56, (14, 18)),
+      (79, (13, 19)),
+      (102, (12, 20)),
+      (126, (11, 21)),
+      (151, (10, 22)),
+      (178, (9, 23)),
+      (207, (8, 24)),
+      (236, (7, 25)),
+      (270, (6, 26)),
+      (308, (5, 27)),
+      (352, (4, 28)),
+      (409, (3, 29)),
+      (499, (2, 30))
+    ]
+
+maxThreshold :: (Rating, Rating)
+maxThreshold = (1, 31)
+
+ratingAdjustment :: Rating -> Rating -> Rating
+ratingAdjustment winner loser
+  | winner >= loser = smallAdjust
+  | otherwise = bigAdjust
+  where
+    diff = abs (winner - loser)
+    (smallAdjust, bigAdjust) = maybe maxThreshold snd (Map.lookupGE diff ratingThresholds)
+
+submitReportHandler :: GameReport -> AppM SubmitGameReportResponse
 submitReportHandler r = case validateReport r of
   Failure errors -> throwError $ err422 {errBody = show errors}
-  Success report -> do
+  Success (GameReport {..}) -> do
     env <- ask
     liftIO . withResource env.dbPool $ \conn -> withTransaction conn $ do
-      winnerId <- insertPlayerIfNotExists conn report.winner
-      loserId <- insertPlayerIfNotExists conn report.loser
-      now <- liftIO getCurrentTime
-      insertGameReport conn $ processReport now winnerId loserId report
+      timestamp <- liftIO getCurrentTime
+      winnerId <- insertPlayerIfNotExists conn winner
+      loserId <- insertPlayerIfNotExists conn loser
+      report <- insertGameReport conn WriteProcessedGameReport {..}
+
+      let winnerSide = report.side
+      let loserSide = case winnerSide of
+            Free -> Shadow
+            Shadow -> Free
+
+      winnerRatingBefore <- getLatestRating conn defaultRating winnerId winnerSide
+      loserRatingBefore <- getLatestRating conn defaultRating loserId loserSide
+      let adjustment = ratingAdjustment winnerRatingBefore loserRatingBefore
+
+      winnerRating <-
+        insertRatingChange
+          conn
+          WriteRatingChange
+            { pid = winnerId,
+              side = winnerSide,
+              timestamp,
+              rid = report.rid,
+              ratingBefore = winnerRatingBefore,
+              ratingAfter = winnerRatingBefore + adjustment
+            }
+      loserRating <-
+        insertRatingChange
+          conn
+          WriteRatingChange
+            { pid = loserId,
+              side = loserSide,
+              timestamp,
+              rid = report.rid,
+              ratingBefore = loserRatingBefore,
+              ratingAfter = loserRatingBefore - adjustment
+            }
+
+      pure $ SubmitGameReportResponse {..}
 
 server :: ServerT Api AppM
 server = submitReportHandler

--- a/backend/src/Database.hs
+++ b/backend/src/Database.hs
@@ -5,22 +5,31 @@ import Data.Pool (withResource)
 import Database.SQLite.Simple (Only (..), execute_, query, query_)
 import Database.SQLite.Simple qualified as SQL
 import Types.App (Env (..), log)
-import Types.DataField (PlayerId, PlayerName)
-import Types.Database (ReadPlayer (..), ReadProcessedGameReport (..), WritePlayer (..), WriteProcessedGameReport (..))
+import Types.DataField (PlayerId, PlayerName, Rating, Side)
+import Types.Database
+  ( ReadPlayer (..),
+    ReadProcessedGameReport (..),
+    WritePlayer (..),
+    WriteProcessedGameReport (..),
+    WriteRatingChange (..),
+  )
 
 data UnexpectedResultException = UnexpectedResultException deriving (Show)
 
 instance Exception UnexpectedResultException
 
-readSingle :: IO [Only r] -> IO r
-readSingle rs = rs >>= \case [Only r] -> pure r; _ -> throwIO UnexpectedResultException
+readZeroOrOne :: IO [r] -> IO (Maybe r)
+readZeroOrOne rs = rs >>= \case [] -> pure Nothing; [r] -> pure $ Just r; _ -> throwIO UnexpectedResultException
+
+readOne :: IO [r] -> IO r
+readOne rs = rs >>= \case [r] -> pure r; _ -> throwIO UnexpectedResultException
 
 initializeDatabase :: ReaderT Env IO ()
 initializeDatabase = do
   env <- ask
   liftIO . withResource env.dbPool $ \conn -> do
     log env.logger "Initializing database"
-    tableCount <- readSingle $ query_ conn "SELECT COUNT(*) FROM sqlite_master WHERE type='table';" :: IO Int
+    tableCount <- fromOnly <$> readOne (query_ conn "SELECT COUNT(*) FROM sqlite_master WHERE type='table';") :: IO Int
     case tableCount of
       0 -> do
         log env.logger "Creating tables"
@@ -30,8 +39,8 @@ initializeDatabase = do
           "CREATE TABLE GameReports (\
           \id INTEGER NOT NULL,\
           \timestamp INTEGER NOT NULL,\
-          \winner INTEGER NOT NULL,\
-          \loser INTEGER NOT NULL,\
+          \winnerId INTEGER NOT NULL,\
+          \loserId INTEGER NOT NULL,\
           \side TEXT NOT NULL,\
           \victory TEXT NOT NULL,\
           \match TEXT NOT NULL,\
@@ -49,11 +58,9 @@ initializeDatabase = do
           \strongholds TEXT NOT NULL,\
           \interestRating INTEGER NOT NULL,\
           \comments TEXT,\
-          \winnerRatingAfter INTEGER NOT NULL,\
-          \loserRatingAfter INTEGER NOT NULL,\
           \PRIMARY KEY(id),\
-          \FOREIGN KEY(winner) REFERENCES Players(id),\
-          \FOREIGN KEY(loser) REFERENCES Players(id)\
+          \FOREIGN KEY(winnerId) REFERENCES Players(id),\
+          \FOREIGN KEY(loserId) REFERENCES Players(id)\
           \);"
         execute_
           conn
@@ -63,19 +70,26 @@ initializeDatabase = do
           \country TEXT,\
           \PRIMARY KEY(id)\
           \);"
+        execute_
+          conn
+          "CREATE TABLE Ratings (\
+          \id INTEGER NOT NULL,\
+          \playerId INTEGER NOT NULL,\
+          \side TEXT NOT NULL,\
+          \timestamp INTEGER NOT NULL,\
+          \reportId INTEGER NOT NULL,\
+          \ratingBefore INTEGER NOT NULL,\
+          \ratingAfter INTEGER NOT NULL,\
+          \PRIMARY KEY(id),\
+          \FOREIGN KEY(playerId) REFERENCES Players(id),\
+          \FOREIGN KEY(reportId) REFERENCES GameReports(id));"
         execute_ conn "CREATE INDEX idx_reports_timestamp ON GameReports (timestamp DESC);"
-        execute_ conn "CREATE INDEX idx_reports_winner_timestamp ON GameReports (winner, timestamp DESC);"
-        execute_ conn "CREATE INDEX idx_reports_loser_timestamp ON GameReports (loser, timestamp DESC);"
         execute_ conn "CREATE INDEX idx_players_name ON Players (name);"
+        execute_ conn "CREATE INDEX idx_ratings_player ON Ratings (playerId, side, timestamp DESC);"
       _ -> log env.logger "Database already initialized"
 
 getPlayerByName :: SQL.Connection -> PlayerName -> IO (Maybe ReadPlayer)
-getPlayerByName conn name = do
-  result <- query conn "SELECT * FROM Players WHERE name = ?" (Only name)
-  case result of
-    [] -> pure Nothing
-    [player] -> pure (Just player)
-    _ -> throwIO UnexpectedResultException
+getPlayerByName conn name = readZeroOrOne $ query conn "SELECT * FROM Players WHERE name = ?" (Only name)
 
 insertPlayerIfNotExists :: SQL.Connection -> PlayerName -> IO PlayerId
 insertPlayerIfNotExists conn name = do
@@ -83,16 +97,38 @@ insertPlayerIfNotExists conn name = do
   case player of
     Nothing -> do
       let insertPlayerQuery = "INSERT INTO Players (name, country) VALUES (?, ?) RETURNING id"
-      readSingle $ query conn insertPlayerQuery (WritePlayer {name, country = Nothing})
+      fromOnly <$> readOne (query conn insertPlayerQuery (WritePlayer {name, country = Nothing}))
     Just (ReadPlayer {pid}) -> pure pid
+
+getLatestRating :: SQL.Connection -> Rating -> PlayerId -> Side -> IO Rating
+getLatestRating conn defaultRating pid side = do
+  let getRatingQuery = "SELECT ratingAfter FROM Ratings WHERE (playerId, side) = (?, ?) ORDER BY timestamp DESC LIMIT 1"
+  rating <- fmap fromOnly <$> readZeroOrOne (query conn getRatingQuery (pid, side))
+  case rating of
+    Nothing -> pure defaultRating
+    Just r -> pure r
+
+insertRatingChange :: SQL.Connection -> WriteRatingChange -> IO Rating
+insertRatingChange conn rating = do
+  let insertRatingQuery =
+        "INSERT INTO Ratings (\
+        \playerId,\
+        \side,\
+        \timestamp,\
+        \reportId,\
+        \ratingBefore,\
+        \ratingAfter\
+        \) VALUES (?, ?, ?, ?, ?, ?)\
+        \RETURNING ratingAfter"
+  fromOnly <$> readOne (query conn insertRatingQuery rating)
 
 insertGameReport :: SQL.Connection -> WriteProcessedGameReport -> IO ReadProcessedGameReport
 insertGameReport conn report@(WriteProcessedGameReport {..}) = do
   let insertReportQuery =
         "INSERT INTO GameReports (\
         \timestamp,\
-        \winner,\
-        \loser,\
+        \winnerId,\
+        \loserId,\
         \side,\
         \victory,\
         \match,\
@@ -109,15 +145,13 @@ insertGameReport conn report@(WriteProcessedGameReport {..}) = do
         \aragornTurn,\
         \strongholds,\
         \interestRating,\
-        \comments,\
-        \winnerRatingAfter,\
-        \loserRatingAfter\
-        \) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)\
+        \comments\
+        \) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)\
         \RETURNING id"
-  rid <- readSingle $ query conn insertReportQuery report
+  rid <- fromOnly <$> readOne (query conn insertReportQuery report)
 
   let nameQuery = "SELECT name FROM Players WHERE id = ?"
-  winner <- readSingle $ query conn nameQuery (Only winnerId)
-  loser <- readSingle $ query conn nameQuery (Only loserId)
+  winner <- fromOnly <$> readOne (query conn nameQuery (Only winnerId))
+  loser <- fromOnly <$> readOne (query conn nameQuery (Only loserId))
 
   pure ReadProcessedGameReport {..}

--- a/backend/src/Types/Api.hs
+++ b/backend/src/Types/Api.hs
@@ -1,7 +1,8 @@
 module Types.Api where
 
 import Data.Aeson (FromJSON, ToJSON)
-import Types.DataField (Competition, Expansion, League, Match, PlayerName, Side, Stronghold, Victory)
+import Types.DataField (Competition, Expansion, League, Match, PlayerName, Rating, Side, Stronghold, Victory)
+import Types.Database (ReadProcessedGameReport)
 
 data GameReport = GameReport
   { winner :: PlayerName,
@@ -26,8 +27,15 @@ data GameReport = GameReport
   }
   deriving (Generic)
 
-instance ToJSON GameReport
-
 instance FromJSON GameReport
+
+data SubmitGameReportResponse = SubmitGameReportResponse
+  { report :: ReadProcessedGameReport,
+    winnerRating :: Rating,
+    loserRating :: Rating
+  }
+  deriving (Generic)
+
+instance ToJSON SubmitGameReportResponse
 
 -- TODO Game Logs

--- a/backend/src/Types/DataField.hs
+++ b/backend/src/Types/DataField.hs
@@ -31,6 +31,12 @@ type PlayerName = Text
 
 type PlayerId = Int
 
+type ReportId = Int
+
+type EloId = Int
+
+type Rating = Int
+
 data Side = Free | Shadow deriving (Eq, Generic, Read, Show)
 
 instance ToField Side where

--- a/backend/src/Types/Database.hs
+++ b/backend/src/Types/Database.hs
@@ -3,7 +3,20 @@ module Types.Database where
 import Data.Aeson (ToJSON)
 import Data.Time (UTCTime)
 import Database.SQLite.Simple (FromRow, ToRow)
-import Types.DataField (Competition, Expansion, League, Match, PlayerId, PlayerName, Side, Stronghold, Victory)
+import Types.DataField
+  ( Competition,
+    EloId,
+    Expansion,
+    League,
+    Match,
+    PlayerId,
+    PlayerName,
+    Rating,
+    ReportId,
+    Side,
+    Stronghold,
+    Victory,
+  )
 
 data WriteProcessedGameReport = WriteProcessedGameReport
   { timestamp :: UTCTime,
@@ -25,9 +38,7 @@ data WriteProcessedGameReport = WriteProcessedGameReport
     aragornTurn :: Maybe Int,
     strongholds :: [Stronghold],
     interestRating :: Int,
-    comments :: Maybe Text,
-    winnerRatingAfter :: Int,
-    loserRatingAfter :: Int
+    comments :: Maybe Text
   }
   deriving (Generic)
 
@@ -54,9 +65,7 @@ data ReadProcessedGameReport = ReadProcessedGameReport
     aragornTurn :: Maybe Int,
     strongholds :: [Stronghold],
     interestRating :: Int,
-    comments :: Maybe Text,
-    winnerRatingAfter :: Int,
-    loserRatingAfter :: Int
+    comments :: Maybe Text
   }
   deriving (Generic)
 
@@ -82,3 +91,27 @@ data ReadPlayer = ReadPlayer
 instance FromRow ReadPlayer
 
 instance ToJSON ReadPlayer
+
+data WriteRatingChange = WriteRatingChange
+  { pid :: PlayerId,
+    side :: Side,
+    timestamp :: UTCTime,
+    rid :: ReportId,
+    ratingBefore :: Rating,
+    ratingAfter :: Rating
+  }
+  deriving (Generic)
+
+instance ToRow WriteRatingChange
+
+data ReadRatingChange = ReadRatingChange
+  { eid :: EloId,
+    side :: Side,
+    timestamp :: UTCTime,
+    rid :: ReportId,
+    ratingBefore :: Rating,
+    ratingAfter :: Rating
+  }
+  deriving (Generic)
+
+instance FromRow ReadRatingChange


### PR DESCRIPTION
This about does it for our basic implementation of submitting a report.

* We receive the report
* Insert players into the DB if necessary
* Insert the report into the DB
* Insert a row representing ratings diffs into the DB

I ended up walking away from storing ratings in the report table directly - kind of a headache. Check out the new schema, as well as the API's return type - see what you think!

![](https://media.giphy.com/media/loefiNrK1fcunvZWBU/giphy.gif?cid=ecf05e47k15ub3qtqgeqfpl69ieg7a9u5thdukzrqcj0syml&ep=v1_gifs_search&rid=giphy.gif&ct=g)