### PR TITLE
Use FormControl wrapper only around single form controls

### DIFF
--- a/frontend/src/GameReportForm.tsx
+++ b/frontend/src/GameReportForm.tsx
@@ -293,10 +293,9 @@ function GameReportForm() {
             <GameReportFormElement
                 label={"What strongholds were captured by Shadow?"}
                 error={formData.strongholds.error}
+                hasSingleControl={false}
             >
-                <VictoryPoints
-                    strongholds={formData.strongholds.value}
-                ></VictoryPoints>
+                <VictoryPoints strongholds={formData.strongholds.value} />
                 <MultiOptionInput
                     values={strongholds.slice()}
                     current={formData.strongholds.value}

--- a/frontend/src/GameReportFormElement.tsx
+++ b/frontend/src/GameReportFormElement.tsx
@@ -1,28 +1,49 @@
 import React from "react";
+import Box from "@mui/joy/Box";
 import FormControl from "@mui/joy/FormControl";
 import FormHelperText from "@mui/joy/FormHelperText";
 import FormLabel from "@mui/joy/FormLabel";
 import Sheet from "@mui/joy/Sheet";
+import { useTheme } from "@mui/joy/styles";
 import { FieldError } from "./types";
 
 interface GameReportElementProps {
     children: React.ReactNode;
     label: string;
     error?: FieldError;
+    hasSingleControl?: boolean;
 }
 
 export default function GameReportFormElement({
     children,
     label,
     error,
+    hasSingleControl = true,
 }: GameReportElementProps) {
+    const theme = useTheme();
+
+    const errorTextStyle = {
+        color: theme.palette.danger.plainColor,
+        marginTop: theme.spacing(1),
+    };
+
+    const formComponents = (
+        <>
+            <FormLabel sx={{ fontSize: 16, pb: 2 }}>{label}</FormLabel>
+            {children}
+            {error && (
+                <FormHelperText sx={errorTextStyle}>{error}</FormHelperText>
+            )}
+        </>
+    );
+
     return (
         <Sheet variant="outlined" sx={{ p: 2, borderRadius: "lg" }}>
-            <FormControl error={!!error}>
-                <FormLabel sx={{ fontSize: 16, pb: 2 }}>{label}</FormLabel>
-                {children}
-                {error && <FormHelperText>{error}</FormHelperText>}
-            </FormControl>
+            {hasSingleControl ? (
+                <FormControl error={!!error}>{formComponents}</FormControl>
+            ) : (
+                <Box>{formComponents}</Box>
+            )}
         </Sheet>
     );
 }


### PR DESCRIPTION
Bandaid for the console error `Joy: A FormControl can contain only one control component (Autocomplete | Input | Textarea | Select | RadioGroup) You should not mix those components inside a single FormControl instance`

I don't love the boolean toggle I did, but I didn't want to to change the implementation of `MultiOptionInput` to use `Select` somehow and be a dropdown multiselect instead of the pretty buttons, and I didn't want a second version of `GameReportFormElement` that might get out of sync in presentation style with the original one, so it's what I landed on 🤷‍♀️ Is there a secret fourth option that would be better?

edit: I guess one more option is to discard the use of `FormControl` completely, but I like the styling it gives to the non-multi-select inputs when there's an error