### PR TITLE
Map form data to a schematically valid HTTP payload

### DIFF
--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -62,6 +62,28 @@ export const optionalFields = [
     "comment",
 ] as const;
 
+export const payloadFields = [
+    "winner",
+    "loser",
+    "side",
+    "victory",
+    "match",
+    "competition",
+    "league",
+    "expansions",
+    "treebeard",
+    "actionTokens",
+    "dwarvenRings",
+    "turns",
+    "corruption",
+    "mordor",
+    "initialEyes",
+    "aragornTurn",
+    "strongholds",
+    "interestRating",
+    "comment",
+] as const;
+
 export enum ErrorMessage {
     Required = "Required",
     OnSubmit = "Could not submit, please resolve errors",

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -49,6 +49,16 @@ export const cities: (typeof strongholds)[number][] = [
     "IronHills",
 ];
 
+export const optionalFields = [
+    "league",
+    "treebeard",
+    "actionTokens",
+    "dwarvenRings",
+    "mordor",
+    "aragornTurn",
+    "comment",
+] as const;
+
 export enum ErrorMessage {
     Required = "Required",
     OnSubmit = "Could not submit, please resolve errors",

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -63,25 +63,16 @@ export const optionalFields = [
 ] as const;
 
 export const payloadFields = [
+    ...optionalFields,
     "winner",
     "loser",
     "side",
     "victory",
     "match",
-    "competition",
-    "league",
-    "expansions",
-    "treebeard",
-    "actionTokens",
-    "dwarvenRings",
     "turns",
     "corruption",
-    "mordor",
     "initialEyes",
-    "aragornTurn",
-    "strongholds",
     "interestRating",
-    "comment",
 ] as const;
 
 export enum ErrorMessage {

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -50,12 +50,15 @@ export const cities: (typeof strongholds)[number][] = [
 ];
 
 export const optionalFields = [
+    "competition",
     "league",
+    "expansions",
     "treebeard",
     "actionTokens",
     "dwarvenRings",
     "mordor",
     "aragornTurn",
+    "strongholds",
     "comment",
 ] as const;
 

--- a/frontend/src/hooks/useFormData/index.tsx
+++ b/frontend/src/hooks/useFormData/index.tsx
@@ -37,12 +37,13 @@ const useFormData = (): [FormData, Meta, Helpers] => {
     const validateField = <K extends keyof FormData>(field: K) => {
         return () => {
             setFormData((prevData) => {
-                const fieldError = prevData[field].validate();
-                const isMissing = isFieldMissing(field, prevData);
                 const error: FieldError =
-                    fieldError || (isMissing && ErrorMessage.Required) || null;
+                    prevData[field].validate() ||
+                    (isFieldMissing(field, prevData) &&
+                        ErrorMessage.Required) ||
+                    null;
 
-                return fieldError || prevData[field].error || isMissing
+                return error || prevData[field].error
                     ? {
                           ...prevData,
                           [field]: { ...prevData[field], error },
@@ -55,10 +56,11 @@ const useFormData = (): [FormData, Meta, Helpers] => {
     const validateForm = (): ValidFormData | ErrorMessage.OnSubmit => {
         const stateUpdates = objectKeys(formData).reduce<(() => void)[]>(
             (updates, field) => {
-                const fieldError = formData[field].validate();
-                const isMissing = isFieldMissing(field, formData);
                 const error: FieldError =
-                    fieldError || (isMissing && ErrorMessage.Required) || null;
+                    formData[field].validate() ||
+                    (isFieldMissing(field, formData) &&
+                        ErrorMessage.Required) ||
+                    null;
 
                 if (error) {
                     updates.push(() =>

--- a/frontend/src/hooks/useFormData/index.tsx
+++ b/frontend/src/hooks/useFormData/index.tsx
@@ -60,7 +60,7 @@ const useFormData = (): [FormData, Meta, Helpers] => {
                 const error: FieldError =
                     fieldError || (isMissing && ErrorMessage.Required) || null;
 
-                if (fieldError || isMissing) {
+                if (error) {
                     updates.push(() =>
                         setFormData((prevData) => ({
                             ...prevData,

--- a/frontend/src/hooks/useFormData/index.tsx
+++ b/frontend/src/hooks/useFormData/index.tsx
@@ -74,8 +74,8 @@ const useFormData = (): [FormData, Meta, Helpers] => {
             []
         );
 
-        if (noErrorsDetected(stateUpdates, formData)) {
-            return formData;
+        if (!stateUpdates.length) {
+            return formData as ValidFormData;
         } else {
             stateUpdates.forEach((update) => update());
             return ErrorMessage.OnSubmit;
@@ -180,13 +180,6 @@ function isFieldMissing(field: keyof FormData, formData: FormData) {
         value === "" ||
         (Array.isArray(value) && !value.length);
     return isEmpty && isRequired;
-}
-
-function noErrorsDetected(
-    errorActions: (() => void)[],
-    formData: FormData
-): formData is ValidFormData {
-    return !errorActions.length;
 }
 
 function toPayload(formData: ValidFormData): GameReportPayload {

--- a/frontend/src/hooks/useFormData/index.tsx
+++ b/frontend/src/hooks/useFormData/index.tsx
@@ -172,10 +172,14 @@ const useFormData = (): [FormData, Meta, Helpers] => {
 export default useFormData;
 
 function isFieldMissing(field: keyof FormData, formData: FormData) {
-    return (
-        formData[field].value === null &&
-        optionalFields.every((opF) => opF !== field)
-    );
+    const { value } = formData[field];
+    const isRequired = optionalFields.every((opF) => opF !== field);
+    const isEmpty =
+        value === null ||
+        value === undefined ||
+        value === "" ||
+        (Array.isArray(value) && !value.length);
+    return isEmpty && isRequired;
 }
 
 function noErrorsDetected(

--- a/frontend/src/hooks/useFormData/initialFormData.tsx
+++ b/frontend/src/hooks/useFormData/initialFormData.tsx
@@ -1,41 +1,30 @@
-import { ErrorMessage } from "../../constants";
-import { FieldError, FormData } from "../../types";
+import { FormData } from "../../types";
 
 const initialFormData: FormData = {
     winner: {
         value: null,
         error: null,
-        validate: function _() {
-            return detectMissingInput(this.value);
-        },
+        validate: alwaysValid,
     },
     loser: {
         value: null,
         error: null,
-        validate: function _() {
-            return detectMissingInput(this.value);
-        },
+        validate: alwaysValid,
     },
     side: {
         value: null,
         error: null,
-        validate: function _() {
-            return detectMissingInput(this.value);
-        },
+        validate: alwaysValid,
     },
     victory: {
         value: null,
         error: null,
-        validate: function _() {
-            return detectMissingInput(this.value);
-        },
+        validate: alwaysValid,
     },
     match: {
         value: null,
         error: null,
-        validate: function _() {
-            return detectMissingInput(this.value);
-        },
+        validate: alwaysValid,
     },
     competition: {
         value: [],
@@ -50,9 +39,7 @@ const initialFormData: FormData = {
     usedExpansions: {
         value: null,
         error: null,
-        validate: function _() {
-            return detectMissingInput(this.value);
-        },
+        validate: alwaysValid,
     },
     expansions: {
         value: [],
@@ -67,32 +54,24 @@ const initialFormData: FormData = {
     usedHandicap: {
         value: null,
         error: null,
-        validate: function _() {
-            return detectMissingInput(this.value);
-        },
+        validate: alwaysValid,
     },
     actionTokens: { value: 0, error: null, validate: alwaysValid },
     dwarvenRings: { value: 0, error: null, validate: alwaysValid },
     turns: {
         value: null,
         error: null,
-        validate: function _() {
-            return detectMissingInput(this.value);
-        },
+        validate: alwaysValid,
     },
     corruption: {
         value: null,
         error: null,
-        validate: function _() {
-            return detectMissingInput(this.value);
-        },
+        validate: alwaysValid,
     },
     didFellowshipReachMordor: {
         value: null,
         error: null,
-        validate: function _() {
-            return detectMissingInput(this.value);
-        },
+        validate: alwaysValid,
     },
     mordor: {
         value: null,
@@ -102,16 +81,12 @@ const initialFormData: FormData = {
     initialEyes: {
         value: null,
         error: null,
-        validate: function _() {
-            return detectMissingInput(this.value);
-        },
+        validate: alwaysValid,
     },
     wasAragornCrowned: {
         value: null,
         error: null,
-        validate: function _() {
-            return detectMissingInput(this.value);
-        },
+        validate: alwaysValid,
     },
     aragornTurn: {
         value: null,
@@ -126,20 +101,12 @@ const initialFormData: FormData = {
     interestRating: {
         value: null,
         error: null,
-        validate: function _() {
-            return detectMissingInput(this.value);
-        },
+        validate: alwaysValid,
     },
     comment: { value: null, error: null, validate: alwaysValid },
 };
 
 export default initialFormData;
-
-function detectMissingInput(value: unknown): FieldError {
-    return value !== null && value !== undefined && value !== ""
-        ? null
-        : ErrorMessage.Required;
-}
 
 function alwaysValid() {
     return null;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -24,9 +24,9 @@ export type League = (typeof leagues)[number];
 
 export type Stronghold = (typeof strongholds)[number];
 
-export type OptionalFields = (typeof optionalFields)[number];
+export type OptionalField = (typeof optionalFields)[number];
 
-export type PayloadFields = (typeof payloadFields)[number];
+export type PayloadField = (typeof payloadFields)[number];
 
 export type FieldError = string | null;
 
@@ -63,15 +63,15 @@ export interface FormData {
 }
 
 export type ValidFormData = {
-    [K in keyof FormData]: K extends OptionalFields
+    [K in keyof FormData]: K extends OptionalField
         ? FormData[K]
         : { [J in keyof FormData[K]]: Exclude<FormData[K][J], null> };
 };
 
 export type GameReportPayload = {
-    [K in keyof Pick<ValidFormData, PayloadFields>]: Pick<
+    [K in keyof Pick<ValidFormData, PayloadField>]: Pick<
         ValidFormData,
-        PayloadFields
+        PayloadField
     >[K]["value"];
 };
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -26,6 +26,8 @@ export type Stronghold = (typeof strongholds)[number];
 
 export type OptionalFields = (typeof optionalFields)[number];
 
+export type PayloadFields = (typeof payloadFields)[number];
+
 export type FieldError = string | null;
 
 export interface FieldData<T> {
@@ -67,7 +69,7 @@ export type ValidFormData = {
 };
 
 export type GameReportPayload = {
-    [K in keyof Pick<ValidFormData, (typeof payloadFields)[number]>]: Pick<
+    [K in keyof Pick<ValidFormData, PayloadFields>]: Pick<
         ValidFormData,
         (typeof payloadFields)[number]
     >[K]["value"];

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -71,7 +71,7 @@ export type ValidFormData = {
 export type GameReportPayload = {
     [K in keyof Pick<ValidFormData, PayloadFields>]: Pick<
         ValidFormData,
-        (typeof payloadFields)[number]
+        PayloadFields
     >[K]["value"];
 };
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -3,6 +3,7 @@ import {
     expansions,
     leagues,
     matchTypes,
+    optionalFields,
     sides,
     strongholds,
     victoryTypes,
@@ -21,6 +22,8 @@ export type Competition = (typeof competitionTypes)[number];
 export type League = (typeof leagues)[number];
 
 export type Stronghold = (typeof strongholds)[number];
+
+export type OptionalFields = (typeof optionalFields)[number];
 
 export type FieldError = string | null;
 
@@ -55,6 +58,12 @@ export interface FormData {
     interestRating: FieldData<number | null>;
     comment: FieldData<string | null>;
 }
+
+export type ValidFormData = {
+    [K in keyof FormData]: K extends OptionalFields
+        ? FormData[K]
+        : { [J in keyof FormData[K]]: Exclude<FormData[K][J], null> };
+};
 
 export interface GameReportPayload {
     winner: string;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -4,6 +4,7 @@ import {
     leagues,
     matchTypes,
     optionalFields,
+    payloadFields,
     sides,
     strongholds,
     victoryTypes,
@@ -65,26 +66,11 @@ export type ValidFormData = {
         : { [J in keyof FormData[K]]: Exclude<FormData[K][J], null> };
 };
 
-export interface GameReportPayload {
-    winner: string;
-    loser: string;
-    side: Side;
-    victory: Victory;
-    match: Match;
-    competition: Competition[];
-    league: League | null;
-    expansions: Expansion[];
-    treebeard: boolean | null;
-    actionTokens: number | null;
-    dwarvenRings: number | null;
-    turns: number;
-    corruption: number;
-    mordor: number | null;
-    initialEyes: number;
-    aragornTurn: number | null;
-    strongholds: Stronghold[];
-    interestRating: number;
-    comment: string | null;
-}
+export type GameReportPayload = {
+    [K in keyof Pick<ValidFormData, (typeof payloadFields)[number]>]: Pick<
+        ValidFormData,
+        (typeof payloadFields)[number]
+    >[K]["value"];
+};
 
 export type ValueOf<T> = T[keyof T];


### PR DESCRIPTION
⚠️ *Does not include mapping of stronghold names to unspaced values* ⚠️

This does a bare minimum transformation of the form data into the schema expected by the server and allows a successful form submission as we saw earlier, hooray! Code-wise though, I was fighting for my life with types on this one and I don't know if what I landed on was the best solution? Will add more details in-line.