### PR TITLE
Why not re-write the server

### DIFF
--- a/backend/.vscode/settings.json
+++ b/backend/.vscode/settings.json
@@ -7,6 +7,7 @@
         "Edoras",
         "Erebor",
         "Ered",
+        "Esqueleto",
         "fmap",
         "fpmv",
         "fprv",
@@ -20,6 +21,7 @@
         "sprv",
         "Tirith",
         "Treebeard",
-        "Unranked"
+        "Unranked",
+        "utct"
     ]
 }

--- a/backend/app/Main.hs
+++ b/backend/app/Main.hs
@@ -47,6 +47,7 @@ main :: IO ()
 main = do
   createDirectoryIfMissing True . takeDirectory $ databaseFile
 
+  -- TODO Fix up debug logging
   dbPool <- runStdoutLoggingT $ createSqlitePoolWithConfig (toText databaseFile) defaultConnectionPoolConfig
   redisPool <- connect redisConfig
   timeCache <- newTimeCache simpleTimeFormat
@@ -54,6 +55,7 @@ main = do
 
   let env = Env {dbPool, redisPool, logger}
 
+  -- TODO Disable/handle auto-migration
   runSqlPool (runMigration migrateAll) dbPool
 
   log logger "Starting server"

--- a/backend/app/Main.hs
+++ b/backend/app/Main.hs
@@ -3,10 +3,9 @@ module Main where
 import Api (api)
 import AppServer (server)
 import Control.Monad.Logger (runStdoutLoggingT)
-import Data.Pool (destroyAllResources)
 import Database.Esqueleto.Experimental (defaultConnectionPoolConfig, runMigration, runSqlPool)
 import Database.Persist.Sqlite (createSqlitePoolWithConfig)
-import Database.Redis (ConnectInfo, connect, defaultConnectInfo, disconnect)
+import Database.Redis (ConnectInfo, connect, defaultConnectInfo)
 import Network.Wai.Handler.Warp (run)
 import Network.Wai.Middleware.Cors (CorsResourcePolicy (..), cors)
 import Servant (Application, hoistServer)
@@ -51,7 +50,7 @@ main = do
   dbPool <- runStdoutLoggingT $ createSqlitePoolWithConfig (toText databaseFile) defaultConnectionPoolConfig
   redisPool <- connect redisConfig
   timeCache <- newTimeCache simpleTimeFormat
-  (logger, rmLogger) <- newTimedFastLogger timeCache logType
+  (logger, _) <- newTimedFastLogger timeCache logType
 
   let env = Env {dbPool, redisPool, logger}
 
@@ -59,8 +58,3 @@ main = do
 
   log logger "Starting server"
   run 8081 . app $ env
-
-  log logger "Shutting down server"
-  destroyAllResources dbPool
-  disconnect redisPool
-  rmLogger

--- a/backend/src/Api.hs
+++ b/backend/src/Api.hs
@@ -1,9 +1,9 @@
 module Api where
 
 import Servant (JSON, Post, ReqBody, (:>))
-import Types.Api (GameReport, SubmitGameReportResponse)
+import Types.Api (RawGameReport, SubmitGameReportResponse)
 
-type SubmitReportAPI = "submitReport" :> ReqBody '[JSON] GameReport :> Post '[JSON] SubmitGameReportResponse
+type SubmitReportAPI = "submitReport" :> ReqBody '[JSON] RawGameReport :> Post '[JSON] SubmitGameReportResponse
 
 submitReportAPI :: Proxy SubmitReportAPI
 submitReportAPI = Proxy

--- a/backend/src/AppServer.hs
+++ b/backend/src/AppServer.hs
@@ -50,6 +50,7 @@ submitReportHandler :: RawGameReport -> AppM SubmitGameReportResponse
 submitReportHandler report = case validateReport report of
   Failure errors -> throwError $ err422 {errBody = show errors}
   Success (RawGameReport {..}) -> do
+    -- TODO Logging in this stupid monad
     response <- runDb $ do
       -- TODO Reduce code duplication
       timestamp <- liftIO getCurrentTime

--- a/backend/src/AppServer.hs
+++ b/backend/src/AppServer.hs
@@ -56,7 +56,7 @@ submitReportHandler report = case validateReport report of
       winnerId <- insertPlayerIfNotExists winner
       loserId <- insertPlayerIfNotExists loser
       reportId <- insertGameReport $ toGameReport timestamp winnerId loserId report
-      winnerStats <- getMostRecentStats winnerId
+      winnerStats <- getMostRecentStats winnerId -- TODO Wrong, should be for current year specifically
       loserStats <- getMostRecentStats loserId
 
       let winnerSide = side

--- a/backend/src/Database.hs
+++ b/backend/src/Database.hs
@@ -1,157 +1,41 @@
 module Database where
 
-import Control.Exception (throwIO)
-import Data.Pool (withResource)
-import Database.SQLite.Simple (Only (..), execute_, query, query_)
-import Database.SQLite.Simple qualified as SQL
-import Types.App (Env (..), log)
-import Types.DataField (PlayerId, PlayerName, Rating, Side)
+import Data.Time (UTCTime (..), getCurrentTime, toGregorian)
+import Database.Esqueleto.Experimental (Entity, Key, SqlPersistT, entityKey)
+import Database.Esqueleto.Experimental qualified as SQL
+import Types.DataField (PlayerName)
 import Types.Database
-  ( ReadPlayer (..),
-    ReadProcessedGameReport (..),
-    WritePlayer (..),
-    WriteProcessedGameReport (..),
-    WriteRatingChange (..),
+  ( GameReport,
+    GameReportId,
+    Key (..),
+    Player (..),
+    PlayerId,
+    PlayerStats (..),
+    RatingDiff,
+    Unique (..),
+    defaultPlayerStats,
   )
 
-data UnexpectedResultException = UnexpectedResultException deriving (Show)
+getPlayerByName :: (MonadIO m) => PlayerName -> SqlPersistT m (Maybe (Entity Player))
+getPlayerByName name = SQL.getBy $ UniquePlayerName name
 
-instance Exception UnexpectedResultException
-
-readZeroOrOne :: IO [r] -> IO (Maybe r)
-readZeroOrOne rs = rs >>= \case [] -> pure Nothing; [r] -> pure $ Just r; _ -> throwIO UnexpectedResultException
-
-readOne :: IO [r] -> IO r
-readOne rs = rs >>= \case [r] -> pure r; _ -> throwIO UnexpectedResultException
-
-initializeDatabase :: ReaderT Env IO ()
-initializeDatabase = do
-  env <- ask
-  liftIO . withResource env.dbPool $ \conn -> do
-    log env.logger "Initializing database"
-    tableCount <- fromOnly <$> readOne (query_ conn "SELECT COUNT(*) FROM sqlite_master WHERE type='table';") :: IO Int
-    case tableCount of
-      0 -> do
-        log env.logger "Creating tables"
-        execute_ conn "PRAGMA foreign_keys = ON;"
-        execute_
-          conn
-          "CREATE TABLE GameReports (\
-          \id INTEGER NOT NULL,\
-          \timestamp INTEGER NOT NULL,\
-          \winnerId INTEGER NOT NULL,\
-          \loserId INTEGER NOT NULL,\
-          \side TEXT NOT NULL,\
-          \victory TEXT NOT NULL,\
-          \match TEXT NOT NULL,\
-          \competition TEXT,\
-          \league TEXT,\
-          \expansions TEXT NOT NULL,\
-          \treebeard INTEGER,\
-          \actionTokens INTEGER NOT NULL,\
-          \dwarvenRings INTEGER NOT NULL,\
-          \turns INTEGER NOT NULL,\
-          \corruption INTEGER NOT NULL,\
-          \mordor INTEGER,\
-          \initialEyes INTEGER NOT NULL,\
-          \aragornTurn INTEGER,\
-          \strongholds TEXT NOT NULL,\
-          \interestRating INTEGER NOT NULL,\
-          \comments TEXT,\
-          \PRIMARY KEY(id),\
-          \FOREIGN KEY(winnerId) REFERENCES Players(id),\
-          \FOREIGN KEY(loserId) REFERENCES Players(id)\
-          \);"
-        execute_
-          conn
-          "CREATE TABLE Players (\
-          \id INTEGER NOT NULL,\
-          \name TEXT NOT NULL UNIQUE,\
-          \country TEXT,\
-          \PRIMARY KEY(id)\
-          \);"
-        execute_
-          conn
-          "CREATE TABLE Ratings (\
-          \id INTEGER NOT NULL,\
-          \playerId INTEGER NOT NULL,\
-          \side TEXT NOT NULL,\
-          \timestamp INTEGER NOT NULL,\
-          \reportId INTEGER NOT NULL,\
-          \ratingBefore INTEGER NOT NULL,\
-          \ratingAfter INTEGER NOT NULL,\
-          \PRIMARY KEY(id),\
-          \FOREIGN KEY(playerId) REFERENCES Players(id),\
-          \FOREIGN KEY(reportId) REFERENCES GameReports(id));"
-        execute_ conn "CREATE INDEX idx_reports_timestamp ON GameReports (timestamp DESC);"
-        execute_ conn "CREATE INDEX idx_players_name ON Players (name);"
-        execute_ conn "CREATE INDEX idx_ratings_player ON Ratings (playerId, side, timestamp DESC);"
-      _ -> log env.logger "Database already initialized"
-
-getPlayerByName :: SQL.Connection -> PlayerName -> IO (Maybe ReadPlayer)
-getPlayerByName conn name = readZeroOrOne $ query conn "SELECT * FROM Players WHERE name = ?" (Only name)
-
-insertPlayerIfNotExists :: SQL.Connection -> PlayerName -> IO PlayerId
-insertPlayerIfNotExists conn name = do
-  player <- getPlayerByName conn name
-  case player of
+insertPlayerIfNotExists :: (MonadIO m) => PlayerName -> SqlPersistT m (Key Player)
+insertPlayerIfNotExists name =
+  getPlayerByName name >>= \case
+    Just player -> pure $ entityKey player
     Nothing -> do
-      let insertPlayerQuery = "INSERT INTO Players (name, country) VALUES (?, ?) RETURNING id"
-      fromOnly <$> readOne (query conn insertPlayerQuery (WritePlayer {name, country = Nothing}))
-    Just (ReadPlayer {pid}) -> pure pid
+      playerKey <- SQL.insert $ Player name Nothing
+      (year, _, _) <- liftIO $ toGregorian . utctDay <$> getCurrentTime
+      SQL.insert_ $ defaultPlayerStats playerKey year
+      pure playerKey
 
-getLatestRating :: SQL.Connection -> Rating -> PlayerId -> Side -> IO Rating
-getLatestRating conn defaultRating pid side = do
-  let getRatingQuery = "SELECT ratingAfter FROM Ratings WHERE (playerId, side) = (?, ?) ORDER BY timestamp DESC LIMIT 1"
-  rating <- fmap fromOnly <$> readZeroOrOne (query conn getRatingQuery (pid, side))
-  case rating of
-    Nothing -> pure defaultRating
-    Just r -> pure r
+getCurrentStats :: (MonadIO m) => PlayerId -> SqlPersistT m (Maybe PlayerStats)
+getCurrentStats pid = do
+  (year, _, _) <- liftIO $ toGregorian . utctDay <$> getCurrentTime
+  SQL.get $ PlayerStatsKey pid (fromIntegral year)
 
-insertRatingChange :: SQL.Connection -> WriteRatingChange -> IO Rating
-insertRatingChange conn rating = do
-  let insertRatingQuery =
-        "INSERT INTO Ratings (\
-        \playerId,\
-        \side,\
-        \timestamp,\
-        \reportId,\
-        \ratingBefore,\
-        \ratingAfter\
-        \) VALUES (?, ?, ?, ?, ?, ?)\
-        \RETURNING ratingAfter"
-  fromOnly <$> readOne (query conn insertRatingQuery rating)
+insertRatingChange :: (MonadIO m) => RatingDiff -> SqlPersistT m ()
+insertRatingChange = SQL.insert_
 
-insertGameReport :: SQL.Connection -> WriteProcessedGameReport -> IO ReadProcessedGameReport
-insertGameReport conn report@(WriteProcessedGameReport {..}) = do
-  let insertReportQuery =
-        "INSERT INTO GameReports (\
-        \timestamp,\
-        \winnerId,\
-        \loserId,\
-        \side,\
-        \victory,\
-        \match,\
-        \competition,\
-        \league,\
-        \expansions,\
-        \treebeard,\
-        \actionTokens,\
-        \dwarvenRings,\
-        \turns,\
-        \corruption,\
-        \mordor,\
-        \initialEyes,\
-        \aragornTurn,\
-        \strongholds,\
-        \interestRating,\
-        \comments\
-        \) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)\
-        \RETURNING id"
-  rid <- fromOnly <$> readOne (query conn insertReportQuery report)
-
-  let nameQuery = "SELECT name FROM Players WHERE id = ?"
-  winner <- fromOnly <$> readOne (query conn nameQuery (Only winnerId))
-  loser <- fromOnly <$> readOne (query conn nameQuery (Only loserId))
-
-  pure ReadProcessedGameReport {..}
+insertGameReport :: (MonadIO m) => GameReport -> SqlPersistT m GameReportId
+insertGameReport = SQL.insert

--- a/backend/src/Database.hs
+++ b/backend/src/Database.hs
@@ -58,6 +58,9 @@ getMostRecentStats pid =
       orderBy [desc (stats ^. PlayerStatsYear)]
       pure stats
 
+replacePlayerStats :: (MonadIO m) => PlayerStats -> SqlPersistT m ()
+replacePlayerStats stats@(PlayerStats {..}) = SQL.replace (PlayerStatsKey playerStatsPlayerId playerStatsYear) stats
+
 insertRatingChange :: (MonadIO m) => RatingDiff -> SqlPersistT m ()
 insertRatingChange = SQL.insert_
 

--- a/backend/src/Database.hs
+++ b/backend/src/Database.hs
@@ -1,13 +1,24 @@
 module Database where
 
 import Data.Time (Year)
-import Database.Esqueleto.Experimental (Entity (..), Key, SqlPersistT, desc, from, orderBy, table, val, where_, (==.), (^.))
+import Database.Esqueleto.Experimental
+  ( Entity (..),
+    Key,
+    SqlPersistT,
+    desc,
+    from,
+    orderBy,
+    table,
+    val,
+    where_,
+    (==.),
+    (^.),
+  )
 import Database.Esqueleto.Experimental qualified as SQL
 import Types.DataField (PlayerName)
 import Types.Database
   ( EntityField (..),
     GameReport,
-    GameReportId,
     Key (..),
     Player (..),
     PlayerId,
@@ -64,5 +75,5 @@ replacePlayerStats stats@(PlayerStats {..}) = SQL.replace (PlayerStatsKey player
 insertRatingChange :: (MonadIO m) => RatingDiff -> SqlPersistT m ()
 insertRatingChange = SQL.insert_
 
-insertGameReport :: (MonadIO m) => GameReport -> SqlPersistT m GameReportId
+insertGameReport :: (MonadIO m) => GameReport -> SqlPersistT m (Key GameReport)
 insertGameReport = SQL.insert

--- a/backend/src/Types/Api.hs
+++ b/backend/src/Types/Api.hs
@@ -1,10 +1,11 @@
 module Types.Api where
 
 import Data.Aeson (FromJSON, ToJSON)
+import Data.Time (UTCTime)
 import Types.DataField (Competition, Expansion, League, Match, PlayerName, Rating, Side, Stronghold, Victory)
-import Types.Database (ReadProcessedGameReport)
+import Types.Database (GameReport (..), PlayerId)
 
-data GameReport = GameReport
+data RawGameReport = RawGameReport
   { winner :: PlayerName,
     loser :: PlayerName,
     side :: Side,
@@ -27,10 +28,37 @@ data GameReport = GameReport
   }
   deriving (Generic)
 
-instance FromJSON GameReport
+instance FromJSON RawGameReport
+
+instance ToJSON RawGameReport
+
+toGameReport :: UTCTime -> PlayerId -> PlayerId -> RawGameReport -> GameReport
+toGameReport timestamp winnerId loserId r =
+  GameReport
+    { gameReportTimestamp = timestamp,
+      gameReportWinnerId = winnerId,
+      gameReportLoserId = loserId,
+      gameReportSide = r.side,
+      gameReportVictory = r.victory,
+      gameReportMatch = r.match,
+      gameReportCompetition = r.competition,
+      gameReportLeague = r.league,
+      gameReportExpansions = r.expansions,
+      gameReportTreebeard = r.treebeard,
+      gameReportActionTokens = r.actionTokens,
+      gameReportDwarvenRings = r.dwarvenRings,
+      gameReportTurns = r.turns,
+      gameReportCorruption = r.corruption,
+      gameReportMordor = r.mordor,
+      gameReportInitialEyes = r.initialEyes,
+      gameReportAragornTurn = r.aragornTurn,
+      gameReportStrongholds = r.strongholds,
+      gameReportInterestRating = r.interestRating,
+      gameReportComments = r.comments
+    }
 
 data SubmitGameReportResponse = SubmitGameReportResponse
-  { report :: ReadProcessedGameReport,
+  { report :: RawGameReport,
     winnerRating :: Rating,
     loserRating :: Rating
   }

--- a/backend/src/Types/App.hs
+++ b/backend/src/Types/App.hs
@@ -1,17 +1,21 @@
 module Types.App where
 
-import Data.Pool (Pool)
+import Database.Esqueleto.Experimental (SqlPersistT)
+import Database.Esqueleto.Experimental qualified as SQL
 import Database.Redis qualified as Redis
-import Database.SQLite.Simple qualified as SQL
 import Servant (Handler)
 import System.Log.FastLogger (LogStr, TimedFastLogger, ToLogStr (..))
 
-data Env = Env {dbPool :: Pool SQL.Connection, redisPool :: Redis.Connection, logger :: TimedFastLogger}
+data Env = Env {dbPool :: SQL.ConnectionPool, redisPool :: Redis.Connection, logger :: TimedFastLogger}
 
 type AppM = ReaderT Env Handler
 
 nt :: Env -> AppM a -> Handler a
-nt s x = runReaderT x s
+nt env server = runReaderT server env
 
+runDb :: SqlPersistT IO a -> AppM a
+runDb dbAction = asks dbPool >>= liftIO . SQL.runSqlPool dbAction
+
+-- TODO Run in handler w/o explicit logger pass?
 log :: TimedFastLogger -> LogStr -> IO ()
 log logger msg = logger (\time -> toLogStr time <> " " <> msg <> "\n")

--- a/backend/src/Types/DataField.hs
+++ b/backend/src/Types/DataField.hs
@@ -2,48 +2,38 @@ module Types.DataField where
 
 import Data.Aeson (FromJSON, ToJSON)
 import Data.Text qualified as T
-import Database.SQLite.Simple (ResultError (..), SQLData (..))
-import Database.SQLite.Simple.FromField (FieldParser, FromField (..), fieldData, returnError)
-import Database.SQLite.Simple.Ok (Ok (..))
-import Database.SQLite.Simple.ToField (ToField (..))
+import Database.Esqueleto.Experimental (PersistField (..), PersistFieldSql, PersistValue (..), SqlType (..))
+import Database.Persist.Sql (PersistFieldSql (..))
 
-defaultToField :: (Show a) => a -> SQLData
-defaultToField a = SQLText (show a)
+defaultToPersistValue :: (Show a) => a -> PersistValue
+defaultToPersistValue a = PersistText (show a)
 
-defaultListToField :: (Show a) => [a] -> SQLData
-defaultListToField as = SQLText (T.intercalate "," . map show $ as)
+defaultListToPersistValue :: (Show a) => [a] -> PersistValue
+defaultListToPersistValue as = PersistText (T.intercalate "," . map show $ as)
 
-defaultFromField :: (Read a, Typeable a) => FieldParser a
-defaultFromField f = case fieldData f of
-  SQLText t -> case readMaybe . toString $ t of
-    Just a -> Ok a
-    Nothing -> returnError ConversionFailed f "Unreadable text field."
-  _ -> returnError ConversionFailed f "Unexpected non-text SQL value."
+defaultFromPersistValue :: (Read a, Typeable a) => PersistValue -> Either Text a
+defaultFromPersistValue v = case v of
+  PersistText t -> maybeToRight "Unreadable text field." (readMaybe . toString $ t)
+  _ -> Left "Unexpected non-text SQL value."
 
-defaultListFromField :: (Read a, Typeable a) => FieldParser [a]
-defaultListFromField f = case fieldData f of
-  SQLText t -> case traverse (readMaybe . toString) . T.splitOn "," $ t of
-    Just a -> Ok a
-    Nothing -> returnError ConversionFailed f "Unreadable value in semantic list text field."
-  _ -> returnError ConversionFailed f "Unexpected non-text SQL value."
+defaultListFromPersistValue :: (Read a, Typeable a) => PersistValue -> Either Text [a]
+defaultListFromPersistValue v = case v of
+  PersistText t ->
+    maybeToRight "Unreadable value in semantic list text field." (traverse (readMaybe . toString) . T.splitOn "," $ t)
+  _ -> Left "Unexpected non-text SQL value."
 
 type PlayerName = Text
-
-type PlayerId = Int
-
-type ReportId = Int
-
-type EloId = Int
 
 type Rating = Int
 
 data Side = Free | Shadow deriving (Eq, Generic, Read, Show)
 
-instance ToField Side where
-  toField = defaultToField
+instance PersistField Side where
+  toPersistValue = defaultToPersistValue
+  fromPersistValue = defaultFromPersistValue
 
-instance FromField Side where
-  fromField = defaultFromField
+instance PersistFieldSql Side where
+  sqlType _ = SqlString
 
 instance ToJSON Side
 
@@ -51,11 +41,12 @@ instance FromJSON Side
 
 data Victory = Ring | Military | Concession deriving (Eq, Generic, Read, Show)
 
-instance ToField Victory where
-  toField = defaultToField
+instance PersistField Victory where
+  toPersistValue = defaultToPersistValue
+  fromPersistValue = defaultFromPersistValue
 
-instance FromField Victory where
-  fromField = defaultFromField
+instance PersistFieldSql Victory where
+  sqlType _ = SqlString
 
 instance ToJSON Victory
 
@@ -63,11 +54,12 @@ instance FromJSON Victory
 
 data Match = Ranked | Unranked deriving (Eq, Generic, Read, Show)
 
-instance ToField Match where
-  toField = defaultToField
+instance PersistField Match where
+  toPersistValue = defaultToPersistValue
+  fromPersistValue = defaultFromPersistValue
 
-instance FromField Match where
-  fromField = defaultFromField
+instance PersistFieldSql Match where
+  sqlType _ = SqlString
 
 instance ToJSON Match
 
@@ -75,11 +67,12 @@ instance FromJSON Match
 
 data Competition = League | Tournament deriving (Eq, Generic, Read, Show)
 
-instance ToField [Competition] where
-  toField = defaultListToField
+instance PersistField [Competition] where
+  toPersistValue = defaultListToPersistValue
+  fromPersistValue = defaultListFromPersistValue
 
-instance FromField [Competition] where
-  fromField = defaultListFromField
+instance PersistFieldSql [Competition] where
+  sqlType _ = SqlString
 
 instance ToJSON Competition
 
@@ -87,11 +80,12 @@ instance FromJSON Competition
 
 data League = GeneralLeague | LoMELeague | WoMELeague | SuperLeague | TTSLeague deriving (Eq, Generic, Read, Show)
 
-instance ToField League where
-  toField = defaultToField
+instance PersistField League where
+  toPersistValue = defaultToPersistValue
+  fromPersistValue = defaultFromPersistValue
 
-instance FromField League where
-  fromField = defaultFromField
+instance PersistFieldSql League where
+  sqlType _ = SqlString
 
 instance ToJSON League
 
@@ -99,11 +93,12 @@ instance FromJSON League
 
 data Expansion = LoME | WoME | KoME | Cities | FateOfErebor | Treebeard deriving (Eq, Generic, Read, Show)
 
-instance ToField [Expansion] where
-  toField = defaultListToField
+instance PersistField [Expansion] where
+  toPersistValue = defaultListToPersistValue
+  fromPersistValue = defaultListFromPersistValue
 
-instance FromField [Expansion] where
-  fromField = defaultListFromField
+instance PersistFieldSql [Expansion] where
+  sqlType _ = SqlString
 
 instance ToJSON Expansion
 
@@ -127,11 +122,12 @@ data Stronghold
   | IronHills
   deriving (Eq, Generic, Read, Show)
 
-instance ToField [Stronghold] where
-  toField = defaultListToField
+instance PersistField [Stronghold] where
+  toPersistValue = defaultListToPersistValue
+  fromPersistValue = defaultListFromPersistValue
 
-instance FromField [Stronghold] where
-  fromField = defaultListFromField
+instance PersistFieldSql [Stronghold] where
+  sqlType _ = SqlString
 
 instance ToJSON Stronghold
 

--- a/backend/src/Types/Database.hs
+++ b/backend/src/Types/Database.hs
@@ -1,117 +1,69 @@
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
+
 module Types.Database where
 
-import Data.Aeson (ToJSON)
-import Data.Time (UTCTime)
-import Database.SQLite.Simple (FromRow, ToRow)
-import Types.DataField
-  ( Competition,
-    EloId,
-    Expansion,
-    League,
-    Match,
-    PlayerId,
-    PlayerName,
-    Rating,
-    ReportId,
-    Side,
-    Stronghold,
-    Victory,
-  )
+import Data.Time (UTCTime, Year)
+import Database.Persist.TH (mkMigrate, mkPersist, persistLowerCase, share, sqlSettings)
+import Types.DataField (Competition, Expansion, League, Match, PlayerName, Rating, Side, Stronghold, Victory)
 
-data WriteProcessedGameReport = WriteProcessedGameReport
-  { timestamp :: UTCTime,
-    winnerId :: PlayerId,
-    loserId :: PlayerId,
-    side :: Side,
-    victory :: Victory,
-    match :: Match,
-    competition :: [Competition],
-    league :: Maybe League,
-    expansions :: [Expansion],
-    treebeard :: Maybe Bool,
-    actionTokens :: Int,
-    dwarvenRings :: Int,
-    turns :: Int,
-    corruption :: Int,
-    mordor :: Maybe Int,
-    initialEyes :: Int,
-    aragornTurn :: Maybe Int,
-    strongholds :: [Stronghold],
-    interestRating :: Int,
-    comments :: Maybe Text
-  }
-  deriving (Generic)
+share
+  [mkPersist sqlSettings, mkMigrate "migrateAll"]
+  [persistLowerCase|
+   Player
+    name PlayerName
+    country Text Maybe
+    UniquePlayerName name
+    deriving Show
 
-instance ToRow WriteProcessedGameReport
+   GameReport
+    timestamp UTCTime
+    winnerId PlayerId
+    loserId PlayerId
+    side Side
+    victory Victory
+    match Match
+    competition [Competition]
+    league League Maybe
+    expansions [Expansion]
+    treebeard Bool Maybe
+    actionTokens Int
+    dwarvenRings Int
+    turns Int
+    corruption Int
+    mordor Int Maybe
+    initialEyes Int
+    aragornTurn Int Maybe
+    strongholds [Stronghold]
+    interestRating Int
+    comments Text Maybe
+    deriving Show
 
-data ReadProcessedGameReport = ReadProcessedGameReport
-  { rid :: Int,
-    timestamp :: UTCTime,
-    winner :: PlayerName,
-    loser :: PlayerName,
-    side :: Side,
-    victory :: Victory,
-    match :: Match,
-    competition :: [Competition],
-    league :: Maybe League,
-    expansions :: [Expansion],
-    treebeard :: Maybe Bool,
-    actionTokens :: Int,
-    dwarvenRings :: Int,
-    turns :: Int,
-    corruption :: Int,
-    mordor :: Maybe Int,
-    initialEyes :: Int,
-    aragornTurn :: Maybe Int,
-    strongholds :: [Stronghold],
-    interestRating :: Int,
-    comments :: Maybe Text
-  }
-  deriving (Generic)
+   RatingDiff
+    timestamp UTCTime
+    playerId PlayerId
+    reportId GameReportId
+    side Side
+    ratingBefore Rating
+    ratingAfter Rating
+    deriving Show
 
-instance FromRow ReadProcessedGameReport
+   PlayerStats
+    playerId PlayerId
+    year Int
+    currentRatingFree Rating
+    currentRatingShadow Rating
+    totalWinsFree Int
+    totalWinsShadow Int
+    totalLossesFree Int
+    totalLossesShadow Int
+    yearlyWinsFree Int
+    yearlyWinsShadow Int
+    yearlyLossesFree Int
+    yearlyLossesShadow Int
+    Primary playerId year
+    deriving Show
+|]
 
-instance ToJSON ReadProcessedGameReport
-
-data WritePlayer = WritePlayer
-  { name :: PlayerName,
-    country :: Maybe Text
-  }
-  deriving (Generic)
-
-instance ToRow WritePlayer
-
-data ReadPlayer = ReadPlayer
-  { pid :: PlayerId,
-    name :: PlayerName,
-    country :: Maybe Text
-  }
-  deriving (Generic)
-
-instance FromRow ReadPlayer
-
-instance ToJSON ReadPlayer
-
-data WriteRatingChange = WriteRatingChange
-  { pid :: PlayerId,
-    side :: Side,
-    timestamp :: UTCTime,
-    rid :: ReportId,
-    ratingBefore :: Rating,
-    ratingAfter :: Rating
-  }
-  deriving (Generic)
-
-instance ToRow WriteRatingChange
-
-data ReadRatingChange = ReadRatingChange
-  { eid :: EloId,
-    side :: Side,
-    timestamp :: UTCTime,
-    rid :: ReportId,
-    ratingBefore :: Rating,
-    ratingAfter :: Rating
-  }
-  deriving (Generic)
-
-instance FromRow ReadRatingChange
+defaultPlayerStats :: PlayerId -> Year -> PlayerStats
+defaultPlayerStats pid year = PlayerStats pid (fromIntegral year) 500 500 0 0 0 0 0 0 0 0

--- a/backend/src/Validation.hs
+++ b/backend/src/Validation.hs
@@ -1,7 +1,7 @@
 module Validation where
 
 import Data.Validation (Validation (..))
-import Types.Api (GameReport (..))
+import Types.Api (RawGameReport (..))
 import Types.DataField (Competition (..), Expansion (..), League (..), Side (..), Stronghold (..), Victory (..))
 
 data ReportError
@@ -40,10 +40,10 @@ vpValue Shadow EredLuin = 1
 vpValue Shadow IronHills = 1
 vpValue _ _ = 0
 
-victoryPoints :: GameReport -> Int
+victoryPoints :: RawGameReport -> Int
 victoryPoints report = sum . map (vpValue report.side) $ report.strongholds
 
-validateVictory :: GameReport -> Validation [ReportError] GameReport
+validateVictory :: RawGameReport -> Validation [ReportError] RawGameReport
 validateVictory report
   | report.corruption >= 12 && not sprv = Failure [VictoryConditionConflictSPRV]
   | report.mordor == Just 5 && not fprv = Failure [VictoryConditionConflictFPRV]
@@ -59,12 +59,12 @@ validateVictory report
     spmv = report.side == Shadow && report.victory == Military
     fpmv = report.side == Free && report.victory == Military
 
-validateCompetition :: GameReport -> Validation [ReportError] GameReport
+validateCompetition :: RawGameReport -> Validation [ReportError] RawGameReport
 validateCompetition report
   | isJust report.league == League `elem` report.competition = Success report
   | otherwise = Failure [CompetitionMismatch]
 
-validateLeague :: GameReport -> Validation [ReportError] GameReport
+validateLeague :: RawGameReport -> Validation [ReportError] RawGameReport
 validateLeague report = case report.league of
   Nothing -> Success report
   Just TTSLeague -> Success report
@@ -74,44 +74,44 @@ validateLeague report = case report.league of
   Just SuperLeague | LoME `elem` report.expansions && WoME `elem` report.expansions -> Success report
   _ -> Failure [LeagueExpansionMismatch]
 
-validateTreebeard :: GameReport -> Validation [ReportError] GameReport
+validateTreebeard :: RawGameReport -> Validation [ReportError] RawGameReport
 validateTreebeard report
   | isJust report.treebeard == Treebeard `elem` report.expansions = Success report
   | otherwise = Failure [TreebeardExpansionMismatch]
 
-validateTurns :: GameReport -> Validation [ReportError] GameReport
+validateTurns :: RawGameReport -> Validation [ReportError] RawGameReport
 validateTurns report
   | report.turns >= 1 = Success report
   | otherwise = Failure [TurnsOutOfRange]
 
-validateCorruption :: GameReport -> Validation [ReportError] GameReport
+validateCorruption :: RawGameReport -> Validation [ReportError] RawGameReport
 validateCorruption report
   | report.corruption >= 0 = Success report
   | otherwise = Failure [CorruptionOutOfRange]
 
-validateMordor :: GameReport -> Validation [ReportError] GameReport
+validateMordor :: RawGameReport -> Validation [ReportError] RawGameReport
 validateMordor report = case report.mordor of
   Nothing -> Success report
   Just step | step >= 0 && step <= 5 -> Success report
   _ -> Failure [MordorOutOfRange]
 
-validateInitialEyes :: GameReport -> Validation [ReportError] GameReport
+validateInitialEyes :: RawGameReport -> Validation [ReportError] RawGameReport
 validateInitialEyes report
   | report.initialEyes >= 0 && report.initialEyes <= 7 = Success report
   | otherwise = Failure [InitialEyesOutOfRange]
 
-validateInterestRating :: GameReport -> Validation [ReportError] GameReport
+validateInterestRating :: RawGameReport -> Validation [ReportError] RawGameReport
 validateInterestRating report
   | report.interestRating >= 1 && report.interestRating <= 10 = Success report
   | otherwise = Failure [InterestRatingOutOfRange]
 
-validateStrongholds :: GameReport -> Validation [ReportError] GameReport
+validateStrongholds :: RawGameReport -> Validation [ReportError] RawGameReport
 validateStrongholds report
   | EredLuin `elem` report.strongholds && Cities `notElem` report.expansions = Failure [InvalidStronghold]
   | IronHills `elem` report.strongholds && FateOfErebor `notElem` report.expansions = Failure [InvalidStronghold]
   | otherwise = Success report
 
-validateReport :: GameReport -> Validation [ReportError] GameReport
+validateReport :: RawGameReport -> Validation [ReportError] RawGameReport
 validateReport report =
   validateVictory report
     <* validateCompetition report

--- a/backend/wotr-community-website.cabal
+++ b/backend/wotr-community-website.cabal
@@ -41,7 +41,6 @@ common dependencies
         servant-server      ^>=0.20.2,
         monad-logger        ^>=0.3.40,
         warp                ^>=3.4.7,
-        resource-pool       ^>=0.4.0.0,
         persistent          ^>=2.14.6.3,
         persistent-sqlite   ^>=2.13.3.0,
         esqueleto           ^>=3.5.13.1,

--- a/backend/wotr-community-website.cabal
+++ b/backend/wotr-community-website.cabal
@@ -20,7 +20,9 @@ common extensions
         DuplicateRecordFields,
         OverloadedRecordDot,
         OverloadedStrings,
-        RecordWildCards
+        RecordWildCards,
+        TypeFamilies,
+        UndecidableInstances,
 
     mixins:
         base hiding (Prelude),
@@ -29,21 +31,24 @@ common extensions
 
 common dependencies
     build-depends:
-        base            ^>=4.20.0.0,
-        relude          ^>=1.2.2.0,
-        filepath        ^>=1.5.4.0,
-        directory       ^>=1.3.9.0,
-        time            ^>=1.12.2,
-        aeson           ^>=2.2.3.0,
-        servant         ^>=0.20.2,
-        servant-server  ^>=0.20.2,
-        warp            ^>=3.4.7,
-        resource-pool   ^>=0.4.0.0,
-        sqlite-simple   ^>=0.4.19.0,
-        fast-logger     ^>=3.2.5,
-        hedis           ^>=0.15.2,
-        validation      ^>=1.1.3,
-        wai-cors        ^>=0.2.7,
+        base                ^>=4.20.0.0,
+        relude              ^>=1.2.2.0,
+        filepath            ^>=1.5.4.0,
+        directory           ^>=1.3.9.0,
+        time                ^>=1.12.2,
+        aeson               ^>=2.2.3.0,
+        servant             ^>=0.20.2,
+        servant-server      ^>=0.20.2,
+        monad-logger        ^>=0.3.40,
+        warp                ^>=3.4.7,
+        resource-pool       ^>=0.4.0.0,
+        persistent          ^>=2.14.6.3,
+        persistent-sqlite   ^>=2.13.3.0,
+        esqueleto           ^>=3.5.13.1,
+        fast-logger         ^>=3.2.5,
+        hedis               ^>=0.15.2,
+        validation          ^>=1.1.3,
+        wai-cors            ^>=0.2.7,
 
 library
     import:           warnings,


### PR DESCRIPTION
![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExZGI3ZmU3b2Z5ZDlvaXhvcW02bnMybGtoMjVoN2pzYmkwcmVoa3N0dyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/61fYIfXvO2EJa/giphy.gif)

I accidentally the server.

The big change here is from using the `sqlite-simple` library to the much more complex/powerful `persistent` library, alongside the companion library `esqueleto` (skeleton in Portuguese, I'm told). I was getting frustrated with how error prone the basic types provided by `sqlite-simple` were - things I would easily accept in any other language, but if we're going to be in Haskell, let's have nice things.

`persistent` is a general library for handling schematized storage in a type-safe way, it has many backends for different kinds of databases (we're still using the sqlite backend), handles schema migrations automagically, and all sorts of nice stuff. `esqueleto` allows for very powerful type-safe queries against the `persistent` database types.

I've had to touch a lot of code to make the change, but I'm hoping the end result will be worth it (or at least make us happier). Please take a look and see what you think - I've left a few TODO's for fast follow-up, but I think this is good for a review pass. 