### PR TITLE
Collect FP strongholds in form and make expansion cities conditional

### DIFF
--- a/backend/src/Types/DataField.hs
+++ b/backend/src/Types/DataField.hs
@@ -123,7 +123,7 @@ data Stronghold
   | MountGundabad
   | Angmar
   | Moria
-  | DolGoldur
+  | DolGuldur
   | Orthanc
   | Morannon
   | BaradDur

--- a/backend/src/Validation.hs
+++ b/backend/src/Validation.hs
@@ -43,7 +43,7 @@ vpValue IronHills = 1
 vpValue MountGundabad = 2
 vpValue Angmar = 1
 vpValue Moria = 2
-vpValue DolGoldur = 2
+vpValue DolGuldur = 2
 vpValue Orthanc = 2
 vpValue Morannon = 2
 vpValue BaradDur = 2
@@ -73,7 +73,7 @@ strongholdSide expansions stronghold
       MountGundabad -> Shadow
       Angmar -> Shadow
       Moria -> Shadow
-      DolGoldur -> Shadow
+      DolGuldur -> Shadow
       Orthanc -> Shadow
       Morannon -> Shadow
       BaradDur -> Shadow

--- a/frontend/src/GameReportForm.tsx
+++ b/frontend/src/GameReportForm.tsx
@@ -431,9 +431,9 @@ function getStrongholdLabel(stronghold: Stronghold): string {
         case "DolAmroth":
             return "Dol Amroth";
         case "EredLuin":
-            return "Ered Luin (Cities expansion only)";
+            return "Ered Luin";
         case "IronHills":
-            return "Iron Hills (Fate of Erebor expansion only)";
+            return "Iron Hills";
         case "MountGundabad":
             return "Mount Gundabad";
         case "DolGuldur":

--- a/frontend/src/GameReportForm.tsx
+++ b/frontend/src/GameReportForm.tsx
@@ -11,9 +11,9 @@ import {
     expansions,
     leagues,
     matchTypes,
-    shadowStrongholds,
     sides,
     staticFreeStrongholds,
+    staticShadowStrongholds,
     victoryTypes,
 } from "./constants";
 import { Expansion, League, Stronghold } from "./types";
@@ -38,7 +38,8 @@ function GameReportForm() {
     ] = useFormData();
 
     const freeStrongholdOptions: Stronghold[] = staticFreeStrongholds.slice();
-    const shadowStrongholdOptions: Stronghold[] = shadowStrongholds.slice();
+    const shadowStrongholdOptions: Stronghold[] =
+        staticShadowStrongholds.slice();
 
     if (isFateOfEreborSelected) {
         shadowStrongholdOptions.push("Erebor");
@@ -49,6 +50,7 @@ function GameReportForm() {
 
     if (isCitiesSelected) {
         freeStrongholdOptions.push("EredLuin");
+        shadowStrongholdOptions.push("SouthRhun");
     }
 
     return (
@@ -445,7 +447,7 @@ function getStrongholdLabel(stronghold: Stronghold): string {
         case "FarHarad":
             return "Far Harad";
         case "SouthRhun":
-            return "South Rhun";
+            return "South Rhûn";
     }
 }
 

--- a/frontend/src/GameReportForm.tsx
+++ b/frontend/src/GameReportForm.tsx
@@ -11,8 +11,8 @@ import {
     expansions,
     leagues,
     matchTypes,
-    strongholds,
     sides,
+    strongholds,
     victoryTypes,
 } from "./constants";
 import { Expansion, League, Stronghold, Side } from "./types";

--- a/frontend/src/GameReportForm.tsx
+++ b/frontend/src/GameReportForm.tsx
@@ -8,20 +8,14 @@ import Sheet from "@mui/joy/Sheet";
 import Button from "@mui/joy/Button";
 import {
     competitionTypes,
-    defaultFreeStrongholds,
-    defaultShadowStrongholds,
     expansions,
     leagues,
     matchTypes,
+    strongholds,
     sides,
     victoryTypes,
 } from "./constants";
-import {
-    Expansion,
-    ExpansionWithStrongholdEffect,
-    League,
-    Stronghold,
-} from "./types";
+import { Expansion, League, Stronghold, Side } from "./types";
 import useFormData from "./hooks/useFormData";
 import GameReportFormElement from "./GameReportFormElement";
 import MultiOptionInput from "./MultiOptionInput";
@@ -37,23 +31,19 @@ function GameReportForm() {
         { handleInputChange, validateField, handleSubmit, setSuccessMessage },
     ] = useFormData();
 
-    const freeStrongholdOptions: Stronghold[] = [
-        ...defaultFreeStrongholds,
-        ...formData.expansions.value
-            .filter(doesExpansionAffectStrongholds)
-            .map(expandFreeStrongholds),
-    ].filter(
+    const { value: selectedExpansions } = formData.expansions;
+
+    const freeStrongholdOptions: Stronghold[] = strongholds.filter(
         (stronghold) =>
-            stronghold !== "Erebor" ||
-            !formData.expansions.value.includes("FateOfErebor")
+            strongholdSide(selectedExpansions, stronghold) === "Free" &&
+            isStrongholdInPlay(selectedExpansions, stronghold)
     );
 
-    const shadowStrongholdOptions: Stronghold[] = [
-        ...defaultShadowStrongholds,
-        ...formData.expansions.value
-            .filter(doesExpansionAffectStrongholds)
-            .map(expandShadowStrongholds),
-    ];
+    const shadowStrongholdOptions: Stronghold[] = strongholds.filter(
+        (stronghold) =>
+            strongholdSide(selectedExpansions, stronghold) === "Shadow" &&
+            isStrongholdInPlay(selectedExpansions, stronghold)
+    );
 
     return (
         <Sheet
@@ -409,31 +399,73 @@ function GameReportForm() {
 
 export default GameReportForm;
 
-function doesExpansionAffectStrongholds(
-    expansion: Expansion
-): expansion is ExpansionWithStrongholdEffect {
-    return expansion === "Cities" || expansion == "FateOfErebor";
-}
-
-function expandFreeStrongholds(
-    expansion: ExpansionWithStrongholdEffect
-): Stronghold {
-    switch (expansion) {
-        case "Cities":
-            return "EredLuin";
-        case "FateOfErebor":
-            return "IronHills";
+function isStrongholdInPlay(
+    expansions: Expansion[],
+    stronghold: Stronghold
+): boolean {
+    switch (stronghold) {
+        case "EredLuin":
+            return expansions.includes("Cities");
+        case "SouthRhun":
+            return expansions.includes("Cities");
+        case "IronHills":
+            return expansions.includes("FateOfErebor");
+        case "Shire":
+        case "Edoras":
+        case "Dale":
+        case "Pelargir":
+        case "Rivendell":
+        case "GreyHavens":
+        case "HelmsDeep":
+        case "Lorien":
+        case "WoodlandRealm":
+        case "MinasTirith":
+        case "DolAmroth":
+        case "Erebor":
+        case "Angmar":
+        case "FarHarad":
+        case "MountGundabad":
+        case "Moria":
+        case "DolGuldur":
+        case "Orthanc":
+        case "Morannon":
+        case "BaradDur":
+        case "MinasMorgul":
+        case "Umbar":
+            return true;
     }
 }
 
-function expandShadowStrongholds(
-    expansion: ExpansionWithStrongholdEffect
-): Stronghold {
-    switch (expansion) {
-        case "Cities":
-            return "SouthRhun";
-        case "FateOfErebor":
-            return "Erebor";
+function strongholdSide(expansions: Expansion[], stronghold: Stronghold): Side {
+    switch (stronghold) {
+        case "Erebor":
+            return expansions.includes("FateOfErebor") ? "Shadow" : "Free";
+        case "Shire":
+        case "Edoras":
+        case "Dale":
+        case "Pelargir":
+        case "EredLuin":
+        case "IronHills":
+        case "Rivendell":
+        case "GreyHavens":
+        case "HelmsDeep":
+        case "Lorien":
+        case "WoodlandRealm":
+        case "MinasTirith":
+        case "DolAmroth":
+            return "Free";
+        case "Angmar":
+        case "FarHarad":
+        case "SouthRhun":
+        case "MountGundabad":
+        case "Moria":
+        case "DolGuldur":
+        case "Orthanc":
+        case "Morannon":
+        case "BaradDur":
+        case "MinasMorgul":
+        case "Umbar":
+            return "Shadow";
     }
 }
 

--- a/frontend/src/GameReportForm.tsx
+++ b/frontend/src/GameReportForm.tsx
@@ -356,7 +356,7 @@ function GameReportForm() {
                 />
             </GameReportFormElement>
             <GameReportFormElement
-                label={"What strongholds were captured by FP?"}
+                label={"What strongholds were captured by Free?"}
                 error={formData.strongholds.error}
                 hasSingleControl={false}
             >

--- a/frontend/src/GameReportForm.tsx
+++ b/frontend/src/GameReportForm.tsx
@@ -11,8 +11,9 @@ import {
     expansions,
     leagues,
     matchTypes,
+    shadowStrongholds,
     sides,
-    strongholds,
+    staticFreeStrongholds,
     victoryTypes,
 } from "./constants";
 import { Expansion, League, Stronghold } from "./types";
@@ -27,9 +28,28 @@ import VictoryPoints from "./VictoryPoints";
 function GameReportForm() {
     const [
         formData,
-        { errorOnSubmit, successMessage },
+        {
+            errorOnSubmit,
+            successMessage,
+            isFateOfEreborSelected,
+            isCitiesSelected,
+        },
         { handleInputChange, validateField, handleSubmit, setSuccessMessage },
     ] = useFormData();
+
+    const freeStrongholdOptions: Stronghold[] = staticFreeStrongholds.slice();
+    const shadowStrongholdOptions: Stronghold[] = shadowStrongholds.slice();
+
+    if (isFateOfEreborSelected) {
+        shadowStrongholdOptions.push("Erebor");
+        freeStrongholdOptions.push("IronHills");
+    } else {
+        freeStrongholdOptions.push("Erebor");
+    }
+
+    if (isCitiesSelected) {
+        freeStrongholdOptions.push("EredLuin");
+    }
 
     return (
         <Sheet
@@ -321,9 +341,29 @@ function GameReportForm() {
                 error={formData.strongholds.error}
                 hasSingleControl={false}
             >
-                <VictoryPoints strongholds={formData.strongholds.value} />
+                <VictoryPoints
+                    strongholds={formData.strongholds.value}
+                    strongholdOptions={freeStrongholdOptions}
+                />
                 <MultiOptionInput
-                    values={strongholds.slice()}
+                    values={freeStrongholdOptions}
+                    current={formData.strongholds.value}
+                    onChange={handleInputChange("strongholds")}
+                    validate={validateField("strongholds")}
+                    getLabel={getStrongholdLabel}
+                />
+            </GameReportFormElement>
+            <GameReportFormElement
+                label={"What strongholds were captured by FP?"}
+                error={formData.strongholds.error}
+                hasSingleControl={false}
+            >
+                <VictoryPoints
+                    strongholds={formData.strongholds.value}
+                    strongholdOptions={shadowStrongholdOptions}
+                />
+                <MultiOptionInput
+                    values={shadowStrongholdOptions}
                     current={formData.strongholds.value}
                     onChange={handleInputChange("strongholds")}
                     validate={validateField("strongholds")}
@@ -374,6 +414,11 @@ function getStrongholdLabel(stronghold: Stronghold): string {
         case "Edoras":
         case "Dale":
         case "Pelargir":
+        case "Angmar":
+        case "Moria":
+        case "Orthanc":
+        case "Morannon":
+        case "Umbar":
             return stronghold;
         case "GreyHavens":
             return "Grey Havens";
@@ -389,6 +434,18 @@ function getStrongholdLabel(stronghold: Stronghold): string {
             return "Ered Luin (Cities expansion only)";
         case "IronHills":
             return "Iron Hills (Fate of Erebor expansion only)";
+        case "MountGundabad":
+            return "Mount Gundabad";
+        case "DolGuldur":
+            return "Dol Guldur";
+        case "BaradDur":
+            return "Barad-dûr";
+        case "MinasMorgul":
+            return "Minas Morgul";
+        case "FarHarad":
+            return "Far Harad";
+        case "SouthRhun":
+            return "South Rhun";
     }
 }
 

--- a/frontend/src/GameReportForm.tsx
+++ b/frontend/src/GameReportForm.tsx
@@ -8,15 +8,20 @@ import Sheet from "@mui/joy/Sheet";
 import Button from "@mui/joy/Button";
 import {
     competitionTypes,
+    defaultFreeStrongholds,
+    defaultShadowStrongholds,
     expansions,
     leagues,
     matchTypes,
     sides,
-    staticFreeStrongholds,
-    staticShadowStrongholds,
     victoryTypes,
 } from "./constants";
-import { Expansion, League, Stronghold } from "./types";
+import {
+    Expansion,
+    ExpansionWithStrongholdEffect,
+    League,
+    Stronghold,
+} from "./types";
 import useFormData from "./hooks/useFormData";
 import GameReportFormElement from "./GameReportFormElement";
 import MultiOptionInput from "./MultiOptionInput";
@@ -28,30 +33,27 @@ import VictoryPoints from "./VictoryPoints";
 function GameReportForm() {
     const [
         formData,
-        {
-            errorOnSubmit,
-            successMessage,
-            isFateOfEreborSelected,
-            isCitiesSelected,
-        },
+        { errorOnSubmit, successMessage },
         { handleInputChange, validateField, handleSubmit, setSuccessMessage },
     ] = useFormData();
 
-    const freeStrongholdOptions: Stronghold[] = staticFreeStrongholds.slice();
-    const shadowStrongholdOptions: Stronghold[] =
-        staticShadowStrongholds.slice();
+    const freeStrongholdOptions: Stronghold[] = [
+        ...defaultFreeStrongholds,
+        ...formData.expansions.value
+            .filter(doesExpansionAffectStrongholds)
+            .map(expandFreeStrongholds),
+    ].filter(
+        (stronghold) =>
+            stronghold !== "Erebor" ||
+            !formData.expansions.value.includes("FateOfErebor")
+    );
 
-    if (isFateOfEreborSelected) {
-        shadowStrongholdOptions.push("Erebor");
-        freeStrongholdOptions.push("IronHills");
-    } else {
-        freeStrongholdOptions.push("Erebor");
-    }
-
-    if (isCitiesSelected) {
-        freeStrongholdOptions.push("EredLuin");
-        shadowStrongholdOptions.push("SouthRhun");
-    }
+    const shadowStrongholdOptions: Stronghold[] = [
+        ...defaultShadowStrongholds,
+        ...formData.expansions.value
+            .filter(doesExpansionAffectStrongholds)
+            .map(expandShadowStrongholds),
+    ];
 
     return (
         <Sheet
@@ -406,6 +408,34 @@ function GameReportForm() {
 }
 
 export default GameReportForm;
+
+function doesExpansionAffectStrongholds(
+    expansion: Expansion
+): expansion is ExpansionWithStrongholdEffect {
+    return expansion === "Cities" || expansion == "FateOfErebor";
+}
+
+function expandFreeStrongholds(
+    expansion: ExpansionWithStrongholdEffect
+): Stronghold {
+    switch (expansion) {
+        case "Cities":
+            return "EredLuin";
+        case "FateOfErebor":
+            return "IronHills";
+    }
+}
+
+function expandShadowStrongholds(
+    expansion: ExpansionWithStrongholdEffect
+): Stronghold {
+    switch (expansion) {
+        case "Cities":
+            return "SouthRhun";
+        case "FateOfErebor":
+            return "Erebor";
+    }
+}
 
 function getStrongholdLabel(stronghold: Stronghold): string {
     switch (stronghold) {

--- a/frontend/src/GameReportForm.tsx
+++ b/frontend/src/GameReportForm.tsx
@@ -28,7 +28,13 @@ function GameReportForm() {
     const [
         formData,
         { errorOnSubmit, successMessage },
-        { handleInputChange, validateField, handleSubmit, setSuccessMessage },
+        {
+            handleInputChange,
+            validateField,
+            handleSubmit,
+            isStrongholdInPlay,
+            setSuccessMessage,
+        },
     ] = useFormData();
 
     const { value: selectedExpansions } = formData.expansions;
@@ -398,43 +404,6 @@ function GameReportForm() {
 }
 
 export default GameReportForm;
-
-function isStrongholdInPlay(
-    expansions: Expansion[],
-    stronghold: Stronghold
-): boolean {
-    switch (stronghold) {
-        case "EredLuin":
-            return expansions.includes("Cities");
-        case "SouthRhun":
-            return expansions.includes("Cities");
-        case "IronHills":
-            return expansions.includes("FateOfErebor");
-        case "Shire":
-        case "Edoras":
-        case "Dale":
-        case "Pelargir":
-        case "Rivendell":
-        case "GreyHavens":
-        case "HelmsDeep":
-        case "Lorien":
-        case "WoodlandRealm":
-        case "MinasTirith":
-        case "DolAmroth":
-        case "Erebor":
-        case "Angmar":
-        case "FarHarad":
-        case "MountGundabad":
-        case "Moria":
-        case "DolGuldur":
-        case "Orthanc":
-        case "Morannon":
-        case "BaradDur":
-        case "MinasMorgul":
-        case "Umbar":
-            return true;
-    }
-}
 
 function strongholdSide(expansions: Expansion[], stronghold: Stronghold): Side {
     switch (stronghold) {

--- a/frontend/src/VictoryPoints.tsx
+++ b/frontend/src/VictoryPoints.tsx
@@ -5,10 +5,15 @@ import { cities } from "./constants";
 
 interface VictoryPointsProps {
     strongholds: Stronghold[];
+    strongholdOptions: Stronghold[];
 }
 
-export default function VictoryPoints({ strongholds }: VictoryPointsProps) {
+export default function VictoryPoints({
+    strongholds,
+    strongholdOptions,
+}: VictoryPointsProps) {
     const points = strongholds
+        .filter((stronghold) => strongholdOptions.includes(stronghold))
         .map((stronghold) => (cities.includes(stronghold) ? 1 : 2))
         .reduce((sum, current) => sum + current, 0);
     return (

--- a/frontend/src/VictoryPoints.tsx
+++ b/frontend/src/VictoryPoints.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import Typography from "@mui/joy/Typography";
 import { Stronghold } from "./types";
-import { cities } from "./constants";
 
 interface VictoryPointsProps {
     strongholds: Stronghold[];
@@ -14,9 +13,41 @@ export default function VictoryPoints({
 }: VictoryPointsProps) {
     const points = strongholds
         .filter((stronghold) => strongholdOptions.includes(stronghold))
-        .map((stronghold) => (cities.includes(stronghold) ? 1 : 2))
+        .map(strongholdPoints)
         .reduce((sum, current) => sum + current, 0);
     return (
         <Typography sx={{ fontWeight: "bold", pb: 2 }}>VP: {points}</Typography>
     );
+}
+
+function strongholdPoints(stronghold: Stronghold): 1 | 2 {
+    switch (stronghold) {
+        case "Shire":
+        case "Edoras":
+        case "Dale":
+        case "Pelargir":
+        case "EredLuin":
+        case "IronHills":
+        case "Angmar":
+        case "FarHarad":
+        case "SouthRhun":
+            return 1;
+        case "Rivendell":
+        case "GreyHavens":
+        case "HelmsDeep":
+        case "Lorien":
+        case "WoodlandRealm":
+        case "MinasTirith":
+        case "DolAmroth":
+        case "Erebor":
+        case "MountGundabad":
+        case "Moria":
+        case "DolGuldur":
+        case "Orthanc":
+        case "Morannon":
+        case "BaradDur":
+        case "MinasMorgul":
+        case "Umbar":
+            return 2;
+    }
 }

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -23,11 +23,11 @@ export const expansions = [
     "Treebeard",
 ] as const;
 
-export const staticShadowCities = ["Angmar", "FarHarad"] as const;
+export const defaultShadowCities = ["Angmar", "FarHarad"] as const;
 
 export const conditionalShadowCities = ["SouthRhun"] as const;
 
-export const staticFreeCities = [
+export const defaultFreeCities = [
     "Shire",
     "Edoras",
     "Dale",
@@ -36,8 +36,8 @@ export const staticFreeCities = [
 
 export const conditionalFreeCities = ["EredLuin", "IronHills"] as const;
 
-export const staticFreeStrongholds = [
-    ...staticFreeCities,
+export const defaultFreeStrongholds = [
+    ...defaultFreeCities,
     "Rivendell",
     "GreyHavens",
     "HelmsDeep",
@@ -45,15 +45,11 @@ export const staticFreeStrongholds = [
     "WoodlandRealm",
     "MinasTirith",
     "DolAmroth",
-] as const;
-
-export const conditionalFreeStrongholds = [
-    ...conditionalFreeCities,
     "Erebor",
 ] as const;
 
-export const staticShadowStrongholds = [
-    ...staticShadowCities,
+export const defaultShadowStrongholds = [
+    ...defaultShadowCities,
     "MountGundabad",
     "Moria",
     "DolGuldur",
@@ -64,21 +60,17 @@ export const staticShadowStrongholds = [
     "Umbar",
 ] as const;
 
-export const conditionalShadowStrongholds = [
-    ...conditionalShadowCities,
-] as const;
-
 export const strongholds = [
-    ...staticShadowStrongholds,
-    ...conditionalShadowStrongholds,
-    ...staticFreeStrongholds,
-    ...conditionalFreeStrongholds,
+    ...defaultShadowStrongholds,
+    ...conditionalShadowCities,
+    ...defaultFreeStrongholds,
+    ...conditionalFreeCities,
 ] as const;
 
 export const cities: (typeof strongholds)[number][] = [
-    ...staticShadowCities,
+    ...defaultShadowCities,
     ...conditionalShadowCities,
-    ...staticFreeCities,
+    ...defaultFreeCities,
     ...conditionalFreeCities,
 ] as const;
 

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -43,9 +43,9 @@ export const defaultFreeStrongholds = [
     "HelmsDeep",
     "Lorien",
     "WoodlandRealm",
+    "Erebor",
     "MinasTirith",
     "DolAmroth",
-    "Erebor",
 ] as const;
 
 export const defaultShadowStrongholds = [

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -23,31 +23,56 @@ export const expansions = [
     "Treebeard",
 ] as const;
 
-export const strongholds = [
+export const shadowCities = ["Angmar", "FarHarad", "SouthRhun"] as const;
+
+export const staticFreeCities = [
+    "Shire",
+    "Edoras",
+    "Dale",
+    "Pelargir",
+] as const;
+
+export const conditionalFreeCities = ["EredLuin", "IronHills"] as const;
+
+export const staticFreeStrongholds = [
+    ...staticFreeCities,
     "Rivendell",
     "GreyHavens",
     "HelmsDeep",
     "Lorien",
     "WoodlandRealm",
-    "Erebor",
     "MinasTirith",
     "DolAmroth",
-    "Shire",
-    "Edoras",
-    "Dale",
-    "Pelargir",
-    "EredLuin",
-    "IronHills",
+] as const;
+
+export const conditionalFreeStrongholds = [
+    ...conditionalFreeCities,
+    "Erebor",
+] as const;
+
+export const shadowStrongholds = [
+    ...shadowCities,
+    "MountGundabad",
+    "Moria",
+    "DolGuldur",
+    "Orthanc",
+    "Morannon",
+    "BaradDur",
+    "MinasMorgul",
+    "Umbar",
+] as const;
+
+export const strongholds = [
+    ...shadowStrongholds,
+    ...staticFreeStrongholds,
+    ...conditionalFreeStrongholds,
 ] as const;
 
 export const cities: (typeof strongholds)[number][] = [
-    "Shire",
-    "Edoras",
-    "Dale",
-    "Pelargir",
-    "EredLuin",
-    "IronHills",
-];
+    ...shadowCities,
+    ...staticFreeCities,
+    ...conditionalFreeCities,
+] as const;
 
 export const optionalFields = [
     "competition",

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -23,7 +23,9 @@ export const expansions = [
     "Treebeard",
 ] as const;
 
-export const shadowCities = ["Angmar", "FarHarad", "SouthRhun"] as const;
+export const staticShadowCities = ["Angmar", "FarHarad"] as const;
+
+export const conditionalShadowCities = ["SouthRhun"] as const;
 
 export const staticFreeCities = [
     "Shire",
@@ -50,8 +52,8 @@ export const conditionalFreeStrongholds = [
     "Erebor",
 ] as const;
 
-export const shadowStrongholds = [
-    ...shadowCities,
+export const staticShadowStrongholds = [
+    ...staticShadowCities,
     "MountGundabad",
     "Moria",
     "DolGuldur",
@@ -62,14 +64,20 @@ export const shadowStrongholds = [
     "Umbar",
 ] as const;
 
+export const conditionalShadowStrongholds = [
+    ...conditionalShadowCities,
+] as const;
+
 export const strongholds = [
-    ...shadowStrongholds,
+    ...staticShadowStrongholds,
+    ...conditionalShadowStrongholds,
     ...staticFreeStrongholds,
     ...conditionalFreeStrongholds,
 ] as const;
 
 export const cities: (typeof strongholds)[number][] = [
-    ...shadowCities,
+    ...staticShadowCities,
+    ...conditionalShadowCities,
     ...staticFreeCities,
     ...conditionalFreeCities,
 ] as const;

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -23,33 +23,20 @@ export const expansions = [
     "Treebeard",
 ] as const;
 
-export const defaultShadowCities = ["Angmar", "FarHarad"] as const;
-
-export const conditionalShadowCities = ["SouthRhun"] as const;
-
-export const defaultFreeCities = [
-    "Shire",
-    "Edoras",
-    "Dale",
-    "Pelargir",
-] as const;
-
-export const conditionalFreeCities = ["EredLuin", "IronHills"] as const;
-
-export const defaultFreeStrongholds = [
-    ...defaultFreeCities,
+export const strongholds = [
     "Rivendell",
     "GreyHavens",
     "HelmsDeep",
     "Lorien",
     "WoodlandRealm",
-    "Erebor",
     "MinasTirith",
     "DolAmroth",
-] as const;
-
-export const defaultShadowStrongholds = [
-    ...defaultShadowCities,
+    "Shire",
+    "Edoras",
+    "Dale",
+    "Pelargir",
+    "EredLuin",
+    "IronHills",
     "MountGundabad",
     "Moria",
     "DolGuldur",
@@ -58,20 +45,10 @@ export const defaultShadowStrongholds = [
     "BaradDur",
     "MinasMorgul",
     "Umbar",
-] as const;
-
-export const strongholds = [
-    ...defaultShadowStrongholds,
-    ...conditionalShadowCities,
-    ...defaultFreeStrongholds,
-    ...conditionalFreeCities,
-] as const;
-
-export const cities: (typeof strongholds)[number][] = [
-    ...defaultShadowCities,
-    ...conditionalShadowCities,
-    ...defaultFreeCities,
-    ...conditionalFreeCities,
+    "Angmar",
+    "FarHarad",
+    "SouthRhun",
+    "Erebor",
 ] as const;
 
 export const optionalFields = [

--- a/frontend/src/hooks/useFormData/index.tsx
+++ b/frontend/src/hooks/useFormData/index.tsx
@@ -4,6 +4,7 @@ import {
     FieldError,
     FormData,
     GameReportPayload,
+    Stronghold,
     SuccessMessage,
     ValidFormData,
     ValueOf,
@@ -23,12 +24,18 @@ type Helpers = {
 type Meta = {
     errorOnSubmit: FieldError;
     successMessage: SuccessMessage;
+    isFateOfEreborSelected: boolean;
+    isCitiesSelected: boolean;
 };
 
 const useFormData = (): [FormData, Meta, Helpers] => {
     const [formData, setFormData] = useState(initialFormData);
     const [errorOnSubmit, setErrorOnSubmit] = useState<FieldError>(null);
     const [successMessage, setSuccessMessage] = useState<SuccessMessage>(null);
+
+    const isFateOfEreborSelected =
+        formData.expansions.value.includes("FateOfErebor");
+    const isCitiesSelected = formData.expansions.value.includes("Cities");
 
     const handleInputChange = <K extends keyof FormData>(field: K) => {
         return (value: FormData[K]["value"]) =>
@@ -144,6 +151,24 @@ const useFormData = (): [FormData, Meta, Helpers] => {
         },
         [successMessage]
     );
+    const useStrongholdDeselectEffect = (
+        deselectValues: Stronghold[],
+        controlCondition: boolean
+    ) => {
+        useEffect(() => {
+            if (!controlCondition) {
+                setFormData((formData) => ({
+                    ...formData,
+                    strongholds: {
+                        ...formData.strongholds,
+                        value: formData.strongholds.value.filter(
+                            (stronghold) => !deselectValues.includes(stronghold)
+                        ),
+                    },
+                }));
+            }
+        }, [controlCondition]);
+    };
 
     useControlledClearEffect(
         formData.match.value,
@@ -172,9 +197,21 @@ const useFormData = (): [FormData, Meta, Helpers] => {
     useControlledClearEffect(formData.didFellowshipReachMordor.value, "mordor");
     useControlledClearEffect(formData.wasAragornCrowned.value, "aragornTurn");
 
+    useStrongholdDeselectEffect(
+        ["IronHills", "Erebor"],
+        isFateOfEreborSelected
+    );
+    useStrongholdDeselectEffect(["Erebor"], !isFateOfEreborSelected);
+    useStrongholdDeselectEffect(["EredLuin"], isCitiesSelected);
+
     return [
         formData,
-        { errorOnSubmit, successMessage },
+        {
+            errorOnSubmit,
+            successMessage,
+            isFateOfEreborSelected,
+            isCitiesSelected,
+        },
         { handleInputChange, validateField, handleSubmit, setSuccessMessage },
     ];
 };

--- a/frontend/src/hooks/useFormData/index.tsx
+++ b/frontend/src/hooks/useFormData/index.tsx
@@ -144,12 +144,6 @@ const useFormData = (): [FormData, Meta, Helpers] => {
         }, [controlField]);
     };
 
-    useEffect(
-        function resetForm() {
-            if (successMessage) setFormData(initialFormData);
-        },
-        [successMessage]
-    );
     const useStrongholdDeselectEffect = (
         deselectedStronghold: Stronghold,
         controlCondition: boolean
@@ -168,6 +162,13 @@ const useFormData = (): [FormData, Meta, Helpers] => {
             }
         }, [controlCondition]);
     };
+
+    useEffect(
+        function resetForm() {
+            if (successMessage) setFormData(initialFormData);
+        },
+        [successMessage]
+    );
 
     useControlledClearEffect(
         formData.match.value,

--- a/frontend/src/hooks/useFormData/index.tsx
+++ b/frontend/src/hooks/useFormData/index.tsx
@@ -202,7 +202,7 @@ const useFormData = (): [FormData, Meta, Helpers] => {
         isFateOfEreborSelected
     );
     useStrongholdDeselectEffect(["Erebor"], !isFateOfEreborSelected);
-    useStrongholdDeselectEffect(["EredLuin"], isCitiesSelected);
+    useStrongholdDeselectEffect(["EredLuin", "SouthRhun"], isCitiesSelected);
 
     return [
         formData,

--- a/frontend/src/hooks/useFormData/index.tsx
+++ b/frontend/src/hooks/useFormData/index.tsx
@@ -24,8 +24,6 @@ type Helpers = {
 type Meta = {
     errorOnSubmit: FieldError;
     successMessage: SuccessMessage;
-    isFateOfEreborSelected: boolean;
-    isCitiesSelected: boolean;
 };
 
 const useFormData = (): [FormData, Meta, Helpers] => {
@@ -206,12 +204,7 @@ const useFormData = (): [FormData, Meta, Helpers] => {
 
     return [
         formData,
-        {
-            errorOnSubmit,
-            successMessage,
-            isFateOfEreborSelected,
-            isCitiesSelected,
-        },
+        { errorOnSubmit, successMessage },
         { handleInputChange, validateField, handleSubmit, setSuccessMessage },
     ];
 };

--- a/frontend/src/hooks/useFormData/index.tsx
+++ b/frontend/src/hooks/useFormData/index.tsx
@@ -36,10 +36,6 @@ const useFormData = (): [FormData, Meta, Helpers] => {
     const [errorOnSubmit, setErrorOnSubmit] = useState<FieldError>(null);
     const [successMessage, setSuccessMessage] = useState<SuccessMessage>(null);
 
-    // const isFateOfEreborSelected =
-    //     formData.expansions.value.includes("FateOfErebor");
-    // const isCitiesSelected = formData.expansions.value.includes("Cities");
-
     const handleInputChange = <K extends keyof FormData>(field: K) => {
         return (value: FormData[K]["value"]) =>
             setFormData((prevData) => ({

--- a/frontend/src/hooks/useFormData/index.tsx
+++ b/frontend/src/hooks/useFormData/index.tsx
@@ -196,7 +196,7 @@ const useFormData = (): [FormData, Meta, Helpers] => {
     useControlledClearEffect(formData.didFellowshipReachMordor.value, "mordor");
     useControlledClearEffect(formData.wasAragornCrowned.value, "aragornTurn");
 
-    strongholds.map((stronghold) => {
+    strongholds.filter(isStrongholdConditional).map((stronghold) => {
         useStrongholdDeselectEffect(
             stronghold,
             isStrongholdInPlay(formData.expansions.value, stronghold)
@@ -288,6 +288,10 @@ function isStrongholdInPlay(
         case "Umbar":
             return true;
     }
+}
+
+function isStrongholdConditional(stronghold: Stronghold): boolean {
+    return !isStrongholdInPlay([], stronghold);
 }
 
 function objectKeys<T extends object>(obj: T): Array<keyof T> {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -30,6 +30,11 @@ export type PayloadField = (typeof payloadFields)[number];
 
 export type SuccessMessage = string | null;
 
+export type ExpansionWithStrongholdEffect = Exclude<
+    Expansion,
+    "LoME" | "KoME" | "WoME" | "Treebeard"
+>;
+
 export type FieldError = string | null;
 
 export interface FieldData<T> {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -30,11 +30,6 @@ export type PayloadField = (typeof payloadFields)[number];
 
 export type SuccessMessage = string | null;
 
-export type ExpansionWithStrongholdEffect = Exclude<
-    Expansion,
-    "LoME" | "KoME" | "WoME" | "Treebeard"
->;
-
 export type FieldError = string | null;
 
 export interface FieldData<T> {


### PR DESCRIPTION
Follow up on discussion in https://github.com/sirrus233/wotr-community-website/pull/33!

I tested different stronghold permutations and the server validation you added works great.

One side note, the server **disallows** reporting 10 shadow VP in case of a FPRV or SPRV - should it be **allowed** because a ring-based victory is checked first?

Also I labeled the new form control `What strongholds were captured by FP?` but do you think FP should be spelled out like Shadow is? And if so do people say `the Free Peoples` or just `Free Peoples`?