### PR TITLE
Display success message and reset game report form after submitting

### DIFF
--- a/frontend/src/GameReportForm.tsx
+++ b/frontend/src/GameReportForm.tsx
@@ -1,5 +1,8 @@
 import "@fontsource/inter";
 import React from "react";
+import Modal from "@mui/joy/Modal";
+import ModalClose from "@mui/joy/ModalClose";
+import ModalDialog from "@mui/joy/ModalDialog";
 import Typography from "@mui/joy/Typography";
 import Sheet from "@mui/joy/Sheet";
 import Button from "@mui/joy/Button";
@@ -24,8 +27,8 @@ import VictoryPoints from "./VictoryPoints";
 function GameReportForm() {
     const [
         formData,
-        { errorOnSubmit },
-        { handleInputChange, validateField, handleSubmit },
+        { errorOnSubmit, successMessage },
+        { handleInputChange, validateField, handleSubmit, setSuccessMessage },
     ] = useFormData();
 
     return (
@@ -44,6 +47,17 @@ function GameReportForm() {
             }}
         >
             <h1>War of the Ring Game Report</h1>
+
+            <Modal
+                open={!!successMessage}
+                onClose={() => setSuccessMessage(null)}
+            >
+                <ModalDialog>
+                    <ModalClose />
+                    <Typography>{successMessage}</Typography>
+                </ModalDialog>
+            </Modal>
+
             <GameReportFormElement
                 label={"Who won?"}
                 error={formData.winner.error}
@@ -191,6 +205,7 @@ function GameReportForm() {
                         <SelectNumericOptionInput
                             start={0}
                             end={8}
+                            current={formData.actionTokens.value}
                             initializeEmpty={false}
                             allowInfinite={true}
                             onChange={handleInputChange("actionTokens")}
@@ -204,6 +219,7 @@ function GameReportForm() {
                         <SelectNumericOptionInput
                             start={0}
                             end={8}
+                            current={formData.dwarvenRings.value}
                             initializeEmpty={false}
                             allowInfinite={true}
                             onChange={handleInputChange("dwarvenRings")}
@@ -219,6 +235,7 @@ function GameReportForm() {
                 <SelectNumericOptionInput
                     start={1}
                     end={25}
+                    current={formData.turns.value}
                     onChange={handleInputChange("turns")}
                     validate={validateField("turns")}
                 />
@@ -230,6 +247,7 @@ function GameReportForm() {
                 <SelectNumericOptionInput
                     start={0}
                     end={18}
+                    current={formData.corruption.value}
                     onChange={handleInputChange("corruption")}
                     validate={validateField("corruption")}
                 />
@@ -254,6 +272,7 @@ function GameReportForm() {
                     <SelectNumericOptionInput
                         start={0}
                         end={5}
+                        current={formData.mordor.value}
                         onChange={handleInputChange("mordor")}
                         validate={validateField("mordor")}
                     />
@@ -266,6 +285,7 @@ function GameReportForm() {
                 <SelectNumericOptionInput
                     start={0}
                     end={7}
+                    current={formData.initialEyes.value}
                     onChange={handleInputChange("initialEyes")}
                     validate={validateField("initialEyes")}
                 />
@@ -290,6 +310,7 @@ function GameReportForm() {
                     <SelectNumericOptionInput
                         start={1}
                         end={18}
+                        current={formData.aragornTurn.value}
                         onChange={handleInputChange("aragornTurn")}
                         validate={validateField("aragornTurn")}
                     />
@@ -318,6 +339,7 @@ function GameReportForm() {
                 <SelectNumericOptionInput
                     start={1}
                     end={10}
+                    current={formData.interestRating.value}
                     onChange={handleInputChange("interestRating")}
                     validate={validateField("interestRating")}
                 />

--- a/frontend/src/SelectNumericOptionInput.tsx
+++ b/frontend/src/SelectNumericOptionInput.tsx
@@ -7,6 +7,7 @@ const NULL_MASK = -1;
 interface SelectNumericOptionInputProps {
     start: number;
     end: number;
+    current: number | null;
     initializeEmpty?: boolean;
     allowInfinite?: boolean;
     onChange: (value: number | null) => void;
@@ -16,6 +17,7 @@ interface SelectNumericOptionInputProps {
 export default function SelectNumericOptionInput({
     start,
     end,
+    current,
     initializeEmpty = true,
     allowInfinite = false,
     onChange,
@@ -32,7 +34,7 @@ export default function SelectNumericOptionInput({
     return (
         <SelectOptionInput
             values={values}
-            current={start}
+            current={maskNull(current)}
             getLabel={(value) => {
                 if (value === NULL_MASK) {
                     return "";
@@ -46,6 +48,10 @@ export default function SelectNumericOptionInput({
             validate={validate}
         />
     );
+}
+
+function maskNull(value: number | null) {
+    return value === null ? NULL_MASK : value;
 }
 
 function unmaskNull(value: number) {

--- a/frontend/src/SelectOptionInput.tsx
+++ b/frontend/src/SelectOptionInput.tsx
@@ -22,6 +22,7 @@ export default function SelectOptionInput<T>({
             defaultValue={values[0]}
             onChange={(_, value) => onChange(value as T)}
             onClose={validate}
+            value={current}
         >
             {values.map((value, i) => (
                 <Option key={i} value={value}>

--- a/frontend/src/hooks/useFormData/index.tsx
+++ b/frontend/src/hooks/useFormData/index.tsx
@@ -4,6 +4,7 @@ import {
     FieldError,
     FormData,
     GameReportPayload,
+    SuccessMessage,
     ValidFormData,
     ValueOf,
 } from "../../types";
@@ -16,15 +17,18 @@ type Helpers = {
     ) => (value: FormData[K]["value"]) => void;
     validateField: <K extends keyof FormData>(field: K) => () => void;
     handleSubmit: () => Promise<void>;
+    setSuccessMessage: (message: SuccessMessage) => void;
 };
 
 type Meta = {
     errorOnSubmit: FieldError;
+    successMessage: SuccessMessage;
 };
 
 const useFormData = (): [FormData, Meta, Helpers] => {
     const [formData, setFormData] = useState(initialFormData);
     const [errorOnSubmit, setErrorOnSubmit] = useState<FieldError>(null);
+    const [successMessage, setSuccessMessage] = useState<SuccessMessage>(null);
 
     const handleInputChange = <K extends keyof FormData>(field: K) => {
         return (value: FormData[K]["value"]) =>
@@ -105,6 +109,8 @@ const useFormData = (): [FormData, Meta, Helpers] => {
 
                 console.log("Form submitted successfully:", response);
                 // Handle the response data as needed
+
+                setSuccessMessage("Report submitted. Thank you!");
             }
         } catch (error) {
             console.error("Error submitting form:", error);
@@ -131,6 +137,13 @@ const useFormData = (): [FormData, Meta, Helpers] => {
             }
         }, [controlField]);
     };
+
+    useEffect(
+        function resetForm() {
+            if (successMessage) setFormData(initialFormData);
+        },
+        [successMessage]
+    );
 
     useControlledClearEffect(
         formData.match.value,
@@ -161,8 +174,8 @@ const useFormData = (): [FormData, Meta, Helpers] => {
 
     return [
         formData,
-        { errorOnSubmit },
-        { handleInputChange, validateField, handleSubmit },
+        { errorOnSubmit, successMessage },
+        { handleInputChange, validateField, handleSubmit, setSuccessMessage },
     ];
 };
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -28,6 +28,8 @@ export type OptionalField = (typeof optionalFields)[number];
 
 export type PayloadField = (typeof payloadFields)[number];
 
+export type SuccessMessage = string | null;
+
 export type FieldError = string | null;
 
 export interface FieldData<T> {


### PR DESCRIPTION
Tried to do the minimum amount of work on this I could! Next will be displaying an error message after a submission.

Uncovered a sneaky bug while adding the `resetForm` effect - the number inputs were uncontrolled components. Totally missed that before!