### PR TITLE
Display partially populated leaderboard

### DIFF
--- a/frontend/src/Rankings.tsx
+++ b/frontend/src/Rankings.tsx
@@ -1,55 +1,276 @@
-import React from "react";
+import axios from "axios";
+import React, { CSSProperties, ReactNode, useEffect, useState } from "react";
+import Box from "@mui/joy/Box";
+import Button from "@mui/joy/Button";
 import Table from "@mui/joy/Table";
+import Typography from "@mui/joy/Typography";
+import { LeaderboardEntry, Side } from "./types";
+
+const CURRENT_YEAR = 2024;
 
 function Rankings() {
+    const [entries, setEntries] = useState<LeaderboardEntry[]>([]);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    const getLeaderboard = async () => {
+        try {
+            const response = await axios.get(
+                "http://localhost:8081/leaderboard"
+            );
+            setEntries(response.data.entries);
+        } catch (error) {
+            setError("Something went wrong");
+            console.error(error);
+        }
+        setLoading(false);
+    };
+
+    const refresh = () => {
+        setLoading(true);
+        getLeaderboard();
+    };
+
+    useEffect(refresh, []);
+
     return (
-        <Table aria-label="basic table">
-            <thead>
-                <tr>
-                    <th style={{ width: "8%" }}>Rank</th>
-                    <th>Player</th>
-                    <th>Avg. Rating</th>
-                    <th>Shadow Rating</th>
-                    <th>Free Rating</th>
-                    <th>Games Played</th>
-                </tr>
-            </thead>
-            <tbody>
-                <tr>
-                    <td>1</td>
-                    <td>Frodo</td>
-                    <td>6</td>
-                    <td>24</td>
-                    <td>4</td>
-                    <td>4</td>
-                </tr>
-                <tr>
-                    <td>2</td>
-                    <td>Sam</td>
-                    <td>9</td>
-                    <td>37</td>
-                    <td>4.3</td>
-                    <td>4</td>
-                </tr>
-                <tr>
-                    <td>3</td>
-                    <td>Merry</td>
-                    <td>16</td>
-                    <td>24</td>
-                    <td>6</td>
-                    <td>1</td>
-                </tr>
-                <tr>
-                    <td>4</td>
-                    <td>Pippin</td>
-                    <td>3.7</td>
-                    <td>67</td>
-                    <td>4.3</td>
-                    <td>6</td>
-                </tr>
-            </tbody>
-        </Table>
+        <Box
+            sx={{
+                display: "flex",
+                flexDirection: "column",
+                gap: 2,
+                m: 2,
+            }}
+        >
+            <Box
+                sx={{
+                    display: "flex",
+                    width: "100%",
+                    alignItems: "center",
+                    justifyContent: "center",
+                }}
+            >
+                <Button onClick={refresh}>Refresh</Button>
+            </Box>
+
+            {error && <Typography color="danger">{error}</Typography>}
+
+            {loading ? (
+                "Loading..."
+            ) : (
+                <Box sx={{ overflow: "auto", py: 1 }}>
+                    <Table
+                        aria-label="Rankings"
+                        noWrap
+                        size="sm"
+                        variant="outlined"
+                        stickyHeader
+                        sx={{
+                            tableLayout: "auto",
+                            borderRadius: "sm",
+                            overflow: "auto",
+                            "& tr > *": { textAlign: "center" },
+                        }}
+                    >
+                        <thead>
+                            <tr>
+                                <TableHeader rowSpan={3}>Rank</TableHeader>
+                                <TableHeader rowSpan={2} colSpan={2}>
+                                    Player
+                                </TableHeader>
+                                <TableHeader
+                                    rowSpan={2}
+                                    style={{ borderBottom: "none" }}
+                                >
+                                    Balanced
+                                </TableHeader>
+                                <TableHeader side="Shadow" rowSpan={3}>
+                                    Shadow Rating
+                                </TableHeader>
+                                <TableHeader side="Free" rowSpan={3}>
+                                    Free Rating
+                                </TableHeader>
+                                <TableHeader rowSpan={3}>Games</TableHeader>
+                                <TableHeader rowSpan={3}>
+                                    Games 2024
+                                </TableHeader>
+                                <TableHeader colSpan={6}>
+                                    Base Game 2024
+                                </TableHeader>
+                                <TableHeader colSpan={6}>LoME 2024</TableHeader>
+                                <TableHeader side="Free" rowSpan={3}>
+                                    # FPMV
+                                </TableHeader>
+                                <TableHeader rowSpan={3}>
+                                    Tournament Wins
+                                </TableHeader>
+                            </tr>
+                            <tr>
+                                {/* Base */}
+                                <TableHeader side="Free" colSpan={3}>
+                                    FP
+                                </TableHeader>
+                                <TableHeader side="Shadow" colSpan={3}>
+                                    SP
+                                </TableHeader>
+
+                                {/* LoME */}
+                                <TableHeader side="Free" colSpan={3}>
+                                    FP
+                                </TableHeader>
+                                <TableHeader side="Shadow" colSpan={3}>
+                                    SP
+                                </TableHeader>
+                            </tr>
+                            <tr>
+                                <TableHeader>Country</TableHeader>
+                                <TableHeader>Name</TableHeader>
+                                <TableHeader>Avg. Rating</TableHeader>
+
+                                {/* FP Base */}
+                                <TableHeader side="Free">Win</TableHeader>
+                                <TableHeader side="Free">Loss</TableHeader>
+                                <TableHeader side="Free">%</TableHeader>
+
+                                {/* SP Base */}
+                                <TableHeader side="Shadow">Win</TableHeader>
+                                <TableHeader side="Shadow">Loss</TableHeader>
+                                <TableHeader side="Shadow">%</TableHeader>
+
+                                {/* FP LOME */}
+                                <TableHeader side="Free">Win</TableHeader>
+                                <TableHeader side="Free">Loss</TableHeader>
+                                <TableHeader side="Free">%</TableHeader>
+
+                                {/* SP LOME */}
+                                <TableHeader side="Shadow">Win</TableHeader>
+                                <TableHeader side="Shadow">Loss</TableHeader>
+                                <TableHeader side="Shadow">%</TableHeader>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {entries.map((entry, i) => (
+                                <tr key={entry.name}>
+                                    <TableCell>{i + 1}</TableCell>
+                                    <TableCell>{entry.country}</TableCell>
+                                    <TableCell>{entry.name}</TableCell>
+                                    <TableCell>{entry.averageRating}</TableCell>
+                                    <TableCell side="Shadow">
+                                        {entry.currentRatingShadow}
+                                    </TableCell>
+                                    <TableCell side="Free">
+                                        {entry.currentRatingFree}
+                                    </TableCell>
+                                    <TableCell>{entry.totalGames}</TableCell>
+                                    <TableCell>
+                                        {entry.year === CURRENT_YEAR &&
+                                            entry.yearlyGames}
+                                    </TableCell>
+                                    <TableCell side="Free" light>
+                                        {entry.year === CURRENT_YEAR &&
+                                            entry.yearlyWinsFree}
+                                    </TableCell>
+                                    <TableCell side="Free">
+                                        {entry.year === CURRENT_YEAR &&
+                                            entry.yearlyLossesFree}
+                                    </TableCell>
+                                    <TableCell side="Free">
+                                        {entry.year === CURRENT_YEAR &&
+                                            entry.yearlyWinRateFree}
+                                    </TableCell>
+                                    <TableCell side="Shadow" light>
+                                        {entry.year === CURRENT_YEAR &&
+                                            entry.yearlyWinsShadow}
+                                    </TableCell>
+                                    <TableCell side="Shadow">
+                                        {entry.year === CURRENT_YEAR &&
+                                            entry.yearlyLossesShadow}
+                                    </TableCell>
+                                    <TableCell side="Shadow">
+                                        {entry.year === CURRENT_YEAR &&
+                                            entry.yearlyWinRateShadow}
+                                    </TableCell>
+                                    <TableCell side="Free" light />
+                                    <TableCell side="Free" />
+                                    <TableCell side="Free" />
+                                    <TableCell side="Shadow" light />
+                                    <TableCell side="Shadow" />
+                                    <TableCell side="Shadow" />
+                                    <TableCell side="Free" light />
+                                    <TableCell />
+                                </tr>
+                            ))}
+                        </tbody>
+                    </Table>
+                </Box>
+            )}
+        </Box>
     );
 }
 
 export default Rankings;
+
+interface TableCellProps {
+    children?: ReactNode;
+    side?: Side;
+    light?: boolean;
+    style?: CSSProperties;
+}
+
+function TableCell({
+    children,
+    side,
+    light = false,
+    style = {},
+}: TableCellProps) {
+    return (
+        <td
+            style={
+                side
+                    ? {
+                          ...style,
+                          backgroundColor:
+                              side === "Shadow" ? "#990200" : "#0b5394",
+                          color: "white",
+                          opacity: light ? "60%" : "100%",
+                      }
+                    : style
+            }
+        >
+            {children}
+        </td>
+    );
+}
+
+interface TableHeaderProps {
+    children?: ReactNode;
+    side?: Side;
+    rowSpan?: number;
+    colSpan?: number;
+    style?: CSSProperties;
+}
+
+function TableHeader({
+    children,
+    side,
+    rowSpan,
+    colSpan,
+    style = {},
+}: TableHeaderProps) {
+    return (
+        <th
+            rowSpan={rowSpan}
+            colSpan={colSpan}
+            style={
+                side
+                    ? {
+                          ...style,
+                          color: side === "Shadow" ? "#990200" : "#0b5394",
+                      }
+                    : style
+            }
+        >
+            {children}
+        </th>
+    );
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -77,4 +77,28 @@ export type GameReportPayload = {
     >[K]["value"];
 };
 
+export interface LeaderboardEntry {
+    pid: number;
+    name: string;
+    country: string | null;
+    currentRatingFree: number;
+    currentRatingShadow: number;
+    averageRating: number;
+    totalGames: number;
+    totalWinsFree: number;
+    totalWinsShadow: number;
+    totalLossesFree: number;
+    totalLossesShadow: number;
+    totalWinRateFree: number;
+    totalWinRateShadow: number;
+    year: number;
+    yearlyGames: number;
+    yearlyWinsFree: number;
+    yearlyWinsShadow: number;
+    yearlyLossesFree: number;
+    yearlyLossesShadow: number;
+    yearlyWinRateFree: number;
+    yearlyWinRateShadow: number;
+}
+
 export type ValueOf<T> = T[keyof T];


### PR DESCRIPTION
A lot of things about this PR are half-baked 😬 but I wanted us to be able to start seeing something before I called it quits!

This PR:
- Shows server-provided stats in a table
- Provides a "Refresh" button

Still left to do:
- Finish populating table with LoME, # FPMV, and tournament win stats
- The year 2024 is hard-coded for now; instead, should display a menu of years for user to choose from
- Make the table's first four columns sticky, like in the spreadsheet
- Add a filter for active vs. inactive players
- Styling, more of that?
- Code cleanup probably, it's not very DRY right now