### PR TITLE
Display game reports

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { CssVarsProvider } from "@mui/joy/styles";
 import CssBaseline from "@mui/joy/CssBaseline";
 import React from "react";
 import GameReportForm from "./GameReportForm";
+import GameReports from "./GameReports";
 import Rankings from "./Rankings";
 import IconButton from "@mui/joy/IconButton";
 import Drawer from "@mui/joy/Drawer";
@@ -18,6 +19,7 @@ export default function App() {
                 <Routes>
                     <Route path="/" element={<Home />} />
                     <Route path="/game-report" element={<GameReportForm />} />
+                    <Route path="/game-reports" element={<GameReports />} />
                     <Route path="/rankings" element={<Rankings />} />
                 </Routes>
             </BrowserRouter>
@@ -68,6 +70,13 @@ function DrawerNavigation() {
                         onClick={() => setOpen(false)}
                     >
                         Rankings
+                    </ListItemButton>
+                    <ListItemButton
+                        component={Link}
+                        to="/game-reports"
+                        onClick={() => setOpen(false)}
+                    >
+                        Game Reports
                     </ListItemButton>
                     <ListItemButton>Leagues (Coming Soon!)</ListItemButton>
                 </List>

--- a/frontend/src/GameReports.tsx
+++ b/frontend/src/GameReports.tsx
@@ -1,0 +1,207 @@
+import axios from "axios";
+import React, { useEffect, useState } from "react";
+import {
+    Competition,
+    Expansion,
+    League,
+    Match,
+    ProcessedGameReport,
+    Side,
+    Stronghold,
+    Victory,
+} from "./types";
+import {
+    getExpansionLabel,
+    getLeagueLabel,
+    getStrongholdLabel,
+    strongholdPoints,
+    strongholdSide,
+} from "./utils";
+import TableView from "./TableView";
+
+export default function GameReports() {
+    const [reports, setReports] = useState<ProcessedGameReport[]>([]);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    const getReports = async () => {
+        try {
+            const response = await axios.get(
+                // "http://localhost:8081/leaderboard"
+                "https://api.waroftheringcommunity.net:8080/reports"
+            );
+            setReports(response.data.reports);
+        } catch (error) {
+            setError("Something went wrong");
+            console.error(error);
+        }
+        setLoading(false);
+    };
+
+    const refresh = () => {
+        setError(null);
+        setLoading(true);
+        getReports();
+    };
+
+    useEffect(refresh, []);
+
+    return (
+        <TableView
+            refresh={refresh}
+            error={error}
+            loading={loading}
+            label="Game Reports"
+            header={
+                <tr>
+                    <th>Pairing</th>
+                    <th>Timestamp</th>
+                    <th>Turn</th>
+                    <th>Winner</th>
+                    <th>Loser</th>
+                    <th>Game Type</th>
+                    <th>Victory Type</th>
+                    <th>Competition Type</th>
+                    <th>Expansions</th>
+                    <th>Tokens</th>
+                    <th>Dwarven Rings</th>
+                    <th>Corruption</th>
+                    <th>Mordor</th>
+                    <th>Aragorn</th>
+                    <th>Treebeard</th>
+                    <th>Initial Eyes</th>
+                    <th>SP-Captured Settlements</th>
+                    <th>SPVP</th>
+                    <th>FP-Captured Settlements</th>
+                    <th>FPVP</th>
+                    <th>Interest Rating</th>
+                    <th>Comments</th>
+                    <th>Game Log</th>
+                    <th>Winning Side</th>
+                    <th>League</th>
+                    <th>Tournament</th>
+                </tr>
+            }
+            body={reports.map((report) => (
+                <tr key={report.rid}>
+                    <td>{[report.winner, report.loser].sort().join("-")}</td>
+                    <td>
+                        {Intl.DateTimeFormat("en-GB").format(
+                            new Date(Date.parse(report.timestamp))
+                        )}
+                    </td>
+                    <td>{report.turns}</td>
+                    <td>{report.winner}</td>
+                    <td>{report.loser}</td>
+                    <td>{summarizeGameType(report.expansions)}</td>
+                    <td>{summarizeVictoryType(report.side, report.victory)}</td>
+                    <td>
+                        {summarizeCompetitionType(
+                            report.match,
+                            report.competition,
+                            report.league
+                        )}
+                    </td>
+                    <td>
+                        {report.expansions.map(getExpansionLabel).join(", ")}
+                    </td>
+                    <td>{report.actionTokens}</td>
+                    <td>{report.dwarvenRings}</td>
+                    <td>{report.corruption}</td>
+                    <td>{report.mordor}</td>
+                    <td>{report.aragornTurn}</td>
+                    <td>{report.treebeard && "✓"}</td>
+                    <td>{report.initialEyes}</td>
+                    <td>
+                        {summarizeCapturedSettlements(
+                            report.strongholds,
+                            report.expansions,
+                            "Free"
+                        )}
+                    </td>
+                    <td>
+                        {countVictoryPoints(
+                            report.strongholds,
+                            report.expansions,
+                            "Free"
+                        )}
+                    </td>
+                    <td>
+                        {summarizeCapturedSettlements(
+                            report.strongholds,
+                            report.expansions,
+                            "Shadow"
+                        )}
+                    </td>
+                    <td>
+                        {countVictoryPoints(
+                            report.strongholds,
+                            report.expansions,
+                            "Shadow"
+                        )}
+                    </td>
+                    <td>{report.interestRating}</td>
+                    <td>{report.comments}</td>
+                    <td></td>
+                    <td>{report.side}</td>
+                    <td>{report.league && "✓"}</td>
+                    <td>{report.competition.includes("Tournament") && "✓"}</td>
+                </tr>
+            ))}
+        />
+    );
+}
+
+function summarizeGameType(expansions: Expansion[]) {
+    return expansions.some(isGameTypeExpansion)
+        ? expansions.filter(isGameTypeExpansion).join("+")
+        : "Base";
+}
+
+function isGameTypeExpansion(expansion: Expansion) {
+    return ["KoME", "WoME", "LoME"].includes(expansion);
+}
+
+function summarizeVictoryType(side: Side, victory: Victory) {
+    return `${side} ${
+        side === "Shadow" && victory === "Ring" ? "Corruption" : victory
+    }`;
+}
+
+function summarizeCompetitionType(
+    match: Match,
+    competition: Competition[],
+    league: League | null
+) {
+    return [
+        match === "Ranked" ? "Ladder" : "Friendly",
+        competition.includes("Tournament") ? "Tournament" : "",
+        competition.includes("League")
+            ? `League${league ? ` (${getLeagueLabel(league)})` : ""}`
+            : "",
+    ]
+        .filter(Boolean)
+        .join(", ");
+}
+
+function summarizeCapturedSettlements(
+    strongholds: Stronghold[],
+    expansions: Expansion[],
+    side: Side
+) {
+    return strongholds
+        .filter((stronghold) => strongholdSide(expansions, stronghold) === side)
+        .map(getStrongholdLabel)
+        .join(", ");
+}
+
+function countVictoryPoints(
+    strongholds: Stronghold[],
+    expansions: Expansion[],
+    side: Side
+) {
+    return strongholds
+        .filter((stronghold) => strongholdSide(expansions, stronghold) === side)
+        .map(strongholdPoints)
+        .reduce((sum, points) => sum + points, 0);
+}

--- a/frontend/src/Rankings.tsx
+++ b/frontend/src/Rankings.tsx
@@ -1,10 +1,7 @@
 import axios from "axios";
 import React, { CSSProperties, ReactNode, useEffect, useState } from "react";
-import Box from "@mui/joy/Box";
-import Button from "@mui/joy/Button";
-import Table from "@mui/joy/Table";
-import Typography from "@mui/joy/Typography";
 import { LeaderboardEntry, Side } from "./types";
+import TableView from "./TableView";
 
 const CURRENT_YEAR = 2024;
 
@@ -36,192 +33,129 @@ function Rankings() {
     useEffect(refresh, []);
 
     return (
-        <Box
-            sx={{
-                display: "flex",
-                flexDirection: "column",
-                gap: 2,
-                m: 2,
-            }}
-        >
-            <Box
-                sx={{
-                    display: "flex",
-                    width: "100%",
-                    alignItems: "center",
-                    justifyContent: "center",
-                }}
-            >
-                <Button onClick={refresh}>Refresh</Button>
-            </Box>
+        <TableView
+            refresh={refresh}
+            error={error}
+            loading={loading}
+            label="Rankings"
+            header={
+                <>
+                    <tr>
+                        <TableHeader rowSpan={3}>Rank</TableHeader>
+                        <TableHeader rowSpan={2} colSpan={2}>
+                            Player
+                        </TableHeader>
+                        <TableHeader
+                            rowSpan={2}
+                            style={{ borderBottom: "none" }}
+                        >
+                            Balanced
+                        </TableHeader>
+                        <TableHeader side="Shadow" rowSpan={3}>
+                            Shadow Rating
+                        </TableHeader>
+                        <TableHeader side="Free" rowSpan={3}>
+                            Free Rating
+                        </TableHeader>
+                        <TableHeader rowSpan={3}>Games</TableHeader>
+                        <TableHeader rowSpan={3}>Games 2024</TableHeader>
+                        <TableHeader colSpan={6}>Base Game 2024</TableHeader>
+                        <TableHeader colSpan={6}>LoME 2024</TableHeader>
+                        <TableHeader side="Free" rowSpan={3}>
+                            # FPMV
+                        </TableHeader>
+                        <TableHeader rowSpan={3}>Tournament Wins</TableHeader>
+                    </tr>
+                    <tr>
+                        {/* Base */}
+                        <TableHeader side="Free" colSpan={3}>
+                            FP
+                        </TableHeader>
+                        <TableHeader side="Shadow" colSpan={3}>
+                            SP
+                        </TableHeader>
 
-            {error && <Typography color="danger">{error}</Typography>}
+                        {/* LoME */}
+                        <TableHeader side="Free" colSpan={3}>
+                            FP
+                        </TableHeader>
+                        <TableHeader side="Shadow" colSpan={3}>
+                            SP
+                        </TableHeader>
+                    </tr>
+                    <tr>
+                        <TableHeader>Country</TableHeader>
+                        <TableHeader>Name</TableHeader>
+                        <TableHeader>Avg. Rating</TableHeader>
 
-            {loading ? (
-                "Loading..."
-            ) : (
-                <Box
-                    sx={{
-                        overflow: "auto",
-                        boxShadow: "lg",
-                        borderRadius: "sm",
-                    }}
-                >
-                    <Table
-                        aria-label="Rankings"
-                        noWrap
-                        size="sm"
-                        variant="outlined"
-                        stickyHeader
-                        sx={{
-                            tableLayout: "auto",
-                            border: "none",
-                            "& tr > *": { textAlign: "center" },
-                            "& thead > tr:first-child > *:first-child": {
-                                pl: 2,
-                            },
-                            "& tbody > tr > *:first-child": { pl: 2 },
-                            "& thead > tr:first-child > *:last-child": {
-                                pr: 2,
-                            },
-                            "& tbody > tr > *:last-child": { pr: 2 },
-                        }}
-                    >
-                        <thead>
-                            <tr>
-                                <TableHeader rowSpan={3}>Rank</TableHeader>
-                                <TableHeader rowSpan={2} colSpan={2}>
-                                    Player
-                                </TableHeader>
-                                <TableHeader
-                                    rowSpan={2}
-                                    style={{ borderBottom: "none" }}
-                                >
-                                    Balanced
-                                </TableHeader>
-                                <TableHeader side="Shadow" rowSpan={3}>
-                                    Shadow Rating
-                                </TableHeader>
-                                <TableHeader side="Free" rowSpan={3}>
-                                    Free Rating
-                                </TableHeader>
-                                <TableHeader rowSpan={3}>Games</TableHeader>
-                                <TableHeader rowSpan={3}>
-                                    Games 2024
-                                </TableHeader>
-                                <TableHeader colSpan={6}>
-                                    Base Game 2024
-                                </TableHeader>
-                                <TableHeader colSpan={6}>LoME 2024</TableHeader>
-                                <TableHeader side="Free" rowSpan={3}>
-                                    # FPMV
-                                </TableHeader>
-                                <TableHeader rowSpan={3}>
-                                    Tournament Wins
-                                </TableHeader>
-                            </tr>
-                            <tr>
-                                {/* Base */}
-                                <TableHeader side="Free" colSpan={3}>
-                                    FP
-                                </TableHeader>
-                                <TableHeader side="Shadow" colSpan={3}>
-                                    SP
-                                </TableHeader>
+                        {/* FP Base */}
+                        <TableHeader side="Free">Win</TableHeader>
+                        <TableHeader side="Free">Loss</TableHeader>
+                        <TableHeader>%</TableHeader>
 
-                                {/* LoME */}
-                                <TableHeader side="Free" colSpan={3}>
-                                    FP
-                                </TableHeader>
-                                <TableHeader side="Shadow" colSpan={3}>
-                                    SP
-                                </TableHeader>
-                            </tr>
-                            <tr>
-                                <TableHeader>Country</TableHeader>
-                                <TableHeader>Name</TableHeader>
-                                <TableHeader>Avg. Rating</TableHeader>
+                        {/* SP Base */}
+                        <TableHeader side="Shadow">Win</TableHeader>
+                        <TableHeader side="Shadow">Loss</TableHeader>
+                        <TableHeader>%</TableHeader>
 
-                                {/* FP Base */}
-                                <TableHeader side="Free">Win</TableHeader>
-                                <TableHeader side="Free">Loss</TableHeader>
-                                <TableHeader>%</TableHeader>
+                        {/* FP LOME */}
+                        <TableHeader side="Free">Win</TableHeader>
+                        <TableHeader side="Free">Loss</TableHeader>
+                        <TableHeader>%</TableHeader>
 
-                                {/* SP Base */}
-                                <TableHeader side="Shadow">Win</TableHeader>
-                                <TableHeader side="Shadow">Loss</TableHeader>
-                                <TableHeader>%</TableHeader>
-
-                                {/* FP LOME */}
-                                <TableHeader side="Free">Win</TableHeader>
-                                <TableHeader side="Free">Loss</TableHeader>
-                                <TableHeader>%</TableHeader>
-
-                                {/* SP LOME */}
-                                <TableHeader side="Shadow">Win</TableHeader>
-                                <TableHeader side="Shadow">Loss</TableHeader>
-                                <TableHeader>%</TableHeader>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {entries.map((entry, i) => (
-                                <tr key={entry.name}>
-                                    <TableCell>{i + 1}</TableCell>
-                                    <TableCell>{entry.country}</TableCell>
-                                    <TableCell>{entry.name}</TableCell>
-                                    <TableCell>{entry.averageRating}</TableCell>
-                                    <TableCell side="Shadow">
-                                        {entry.currentRatingShadow}
-                                    </TableCell>
-                                    <TableCell side="Free">
-                                        {entry.currentRatingFree}
-                                    </TableCell>
-                                    <TableCell>{entry.totalGames}</TableCell>
-                                    <TableCell>
-                                        {entry.year === CURRENT_YEAR &&
-                                            entry.yearlyGames}
-                                    </TableCell>
-                                    <TableCell side="Free" light>
-                                        {entry.year === CURRENT_YEAR &&
-                                            entry.yearlyWinsFree}
-                                    </TableCell>
-                                    <TableCell side="Free">
-                                        {entry.year === CURRENT_YEAR &&
-                                            entry.yearlyLossesFree}
-                                    </TableCell>
-                                    <TableCell>
-                                        {entry.year === CURRENT_YEAR &&
-                                            toPercent(entry.yearlyWinRateFree)}
-                                    </TableCell>
-                                    <TableCell side="Shadow" light>
-                                        {entry.year === CURRENT_YEAR &&
-                                            entry.yearlyWinsShadow}
-                                    </TableCell>
-                                    <TableCell side="Shadow">
-                                        {entry.year === CURRENT_YEAR &&
-                                            entry.yearlyLossesShadow}
-                                    </TableCell>
-                                    <TableCell>
-                                        {entry.year === CURRENT_YEAR &&
-                                            toPercent(
-                                                entry.yearlyWinRateShadow
-                                            )}
-                                    </TableCell>
-                                    <TableCell side="Free" light />
-                                    <TableCell side="Free" />
-                                    <TableCell />
-                                    <TableCell side="Shadow" light />
-                                    <TableCell side="Shadow" />
-                                    <TableCell />
-                                    <TableCell side="Free" light />
-                                    <TableCell />
-                                </tr>
-                            ))}
-                        </tbody>
-                    </Table>
-                </Box>
-            )}
-        </Box>
+                        {/* SP LOME */}
+                        <TableHeader side="Shadow">Win</TableHeader>
+                        <TableHeader side="Shadow">Loss</TableHeader>
+                        <TableHeader>%</TableHeader>
+                    </tr>
+                </>
+            }
+            body={entries.map((entry, i) => (
+                <tr key={entry.name}>
+                    <TableCell>{i + 1}</TableCell>
+                    <TableCell>{entry.country}</TableCell>
+                    <TableCell>{entry.name}</TableCell>
+                    <TableCell>{entry.averageRating}</TableCell>
+                    <TableCell side="Shadow">
+                        {entry.currentRatingShadow}
+                    </TableCell>
+                    <TableCell side="Free">{entry.currentRatingFree}</TableCell>
+                    <TableCell>{entry.totalGames}</TableCell>
+                    <TableCell>
+                        {entry.year === CURRENT_YEAR && entry.yearlyGames}
+                    </TableCell>
+                    <TableCell side="Free" light>
+                        {entry.year === CURRENT_YEAR && entry.yearlyWinsFree}
+                    </TableCell>
+                    <TableCell side="Free">
+                        {entry.year === CURRENT_YEAR && entry.yearlyLossesFree}
+                    </TableCell>
+                    <TableCell>
+                        {entry.year === CURRENT_YEAR &&
+                            toPercent(entry.yearlyWinRateFree)}
+                    </TableCell>
+                    <TableCell side="Shadow" light>
+                        {entry.year === CURRENT_YEAR && entry.yearlyWinsShadow}
+                    </TableCell>
+                    <TableCell side="Shadow">
+                        {entry.year === CURRENT_YEAR &&
+                            entry.yearlyLossesShadow}
+                    </TableCell>
+                    <TableCell>
+                        {entry.year === CURRENT_YEAR &&
+                            toPercent(entry.yearlyWinRateShadow)}
+                    </TableCell>
+                    <TableCell side="Free" light />
+                    <TableCell side="Free" />
+                    <TableCell />
+                    <TableCell side="Shadow" light />
+                    <TableCell side="Shadow" />
+                    <TableCell />
+                    <TableCell side="Free" light />
+                    <TableCell />
+                </tr>
+            ))}
+        />
     );
 }
 

--- a/frontend/src/TableView.tsx
+++ b/frontend/src/TableView.tsx
@@ -1,0 +1,83 @@
+import React, { ReactNode } from "react";
+import Box from "@mui/joy/Box";
+import Button from "@mui/joy/Button";
+import Table from "@mui/joy/Table";
+import Typography from "@mui/joy/Typography";
+
+interface Props {
+    refresh: () => void;
+    error: string | null;
+    loading: boolean;
+    label: string;
+    header: ReactNode;
+    body: ReactNode;
+}
+
+export default function TableView({
+    refresh,
+    error,
+    loading,
+    label,
+    header,
+    body,
+}: Props) {
+    return (
+        <Box
+            sx={{
+                display: "flex",
+                flexDirection: "column",
+                gap: 2,
+                m: 2,
+            }}
+        >
+            <Box
+                sx={{
+                    display: "flex",
+                    width: "100%",
+                    alignItems: "center",
+                    justifyContent: "center",
+                }}
+            >
+                <Button onClick={refresh}>Refresh</Button>
+            </Box>
+
+            {error && <Typography color="danger">{error}</Typography>}
+
+            {loading ? (
+                "Loading..."
+            ) : (
+                <Box
+                    sx={{
+                        overflow: "auto",
+                        boxShadow: "lg",
+                        borderRadius: "sm",
+                    }}
+                >
+                    <Table
+                        aria-label={label}
+                        noWrap
+                        size="sm"
+                        variant="outlined"
+                        stickyHeader
+                        sx={{
+                            tableLayout: "auto",
+                            border: "none",
+                            "& tr > *": { textAlign: "center" },
+                            "& thead > tr:first-child > *:first-child": {
+                                pl: 2,
+                            },
+                            "& tbody > tr > *:first-child": { pl: 2 },
+                            "& thead > tr:first-child > *:last-child": {
+                                pr: 2,
+                            },
+                            "& tbody > tr > *:last-child": { pr: 2 },
+                        }}
+                    >
+                        <thead>{header}</thead>
+                        <tbody>{body}</tbody>
+                    </Table>
+                </Box>
+            )}
+        </Box>
+    );
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -112,4 +112,30 @@ export interface LeaderboardEntry {
     yearlyWinRateShadow: number;
 }
 
+export interface ProcessedGameReport {
+    rid: number;
+    timestamp: string;
+    winnerId: number;
+    winner: string;
+    loserId: number;
+    loser: string;
+    side: Side;
+    victory: Victory;
+    match: Match;
+    competition: Competition[];
+    league: League | null;
+    expansions: Expansion[];
+    treebeard: boolean | null;
+    actionTokens: number;
+    dwarvenRings: number;
+    turns: number;
+    corruption: number;
+    mordor: number | null;
+    initialEyes: number;
+    aragornTurn: number | null;
+    strongholds: Stronghold[];
+    interestRating: number;
+    comments: string | null;
+}
+
 export type ValueOf<T> = T[keyof T];


### PR DESCRIPTION
Once again did this a little quickly, so there's probably stuff missing, but initial pass!

Still left to do:
- We should audit the columns against the ones we want to keep from the spreadsheet
- I want to submit more variations of game reports to make sure all the variations of summarized values get displayed as intended
- Line wrapping in the table cells might be good since a line will just extend horizontally forever now
- I just realized frontend uses `comment` and backend uses `comments` in a game report haha...will fix that. Idk if submitting a form with a comment will break it because of that, haven't tried
- Game log field isn't populated yet obvs since that's not ready yet