### PR TITLE
Limit ladder and game report table heights and make row headers sticky

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,6 +15,7 @@ import MenuIcon from "@mui/icons-material/Menu";
 import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import Typography from "@mui/joy/Typography";
 import { BrowserRouter, Routes, Route, Link } from "react-router-dom";
+import { HEADER_HEIGHT_PX, HEADER_MARGIN_PX } from "./styles/sizes";
 
 export default function App() {
     return (
@@ -26,11 +27,12 @@ export default function App() {
                         display: "flex",
                         alignItems: "center",
                         width: "100%",
+                        height: `${HEADER_HEIGHT_PX}px`,
                         position: "sticky",
                         top: 0,
                         zIndex: 1000,
-                        margin: "0 0 20px 0",
-                        padding: "10px 10px",
+                        margin: `0 0 ${HEADER_MARGIN_PX}px 0`,
+                        padding: "0 10px",
                         boxShadow: "0 0 2px 0 rgba(0, 0, 0, 0.5)",
                         color: "white",
                         backgroundColor: "var(--joy-palette-primary-solidBg)",

--- a/frontend/src/GameReports.tsx
+++ b/frontend/src/GameReports.tsx
@@ -12,6 +12,13 @@ import {
     Stronghold,
     Victory,
 } from "./types";
+import { FREE_ACCENT_COLOR, SHADOW_PRIMARY_COLOR } from "./styles/colors";
+import {
+    HEADER_HEIGHT_PX,
+    HEADER_MARGIN_PX,
+    TABLE_REFRESH_BTN_HEIGHT_PX,
+    TABLE_ELEMENTS_GAP,
+} from "./styles/sizes";
 import {
     getExpansionLabel,
     getLeagueLabel,
@@ -21,8 +28,11 @@ import {
 } from "./utils";
 import TableView from "./TableView";
 
-const FREE_ACCENT_COLOR = "#3f99ff";
-const SHADOW_ACCENT_COLOR = "#990200";
+const TABLE_TOP_POSITION =
+    HEADER_HEIGHT_PX +
+    HEADER_MARGIN_PX +
+    TABLE_REFRESH_BTN_HEIGHT_PX +
+    TABLE_ELEMENTS_GAP * 2;
 
 export default function GameReports() {
     const [reports, setReports] = useState<ProcessedGameReport[]>([]);
@@ -57,6 +67,9 @@ export default function GameReports() {
             error={error}
             loading={loading}
             label="Game Reports"
+            containerStyle={{
+                maxHeight: `calc(100vh - ${TABLE_TOP_POSITION}px - ${TABLE_ELEMENTS_GAP}px)`,
+            }}
             header={
                 <tr>
                     <th />
@@ -189,7 +202,7 @@ function RowAccent({ side }: RowAccentProps) {
                     background:
                         side === "Free"
                             ? FREE_ACCENT_COLOR
-                            : SHADOW_ACCENT_COLOR,
+                            : SHADOW_PRIMARY_COLOR,
                 }}
             />
         </td>
@@ -212,7 +225,7 @@ function summarizeVictoryType(side: Side, victory: Victory) {
             style={{
                 color: "white",
                 background:
-                    side === "Free" ? FREE_ACCENT_COLOR : SHADOW_ACCENT_COLOR,
+                    side === "Free" ? FREE_ACCENT_COLOR : SHADOW_PRIMARY_COLOR,
                 borderRadius: "12px",
                 padding: "3px 8px",
             }}

--- a/frontend/src/Rankings.tsx
+++ b/frontend/src/Rankings.tsx
@@ -4,11 +4,28 @@ import Box from "@mui/joy/Box";
 import Button from "@mui/joy/Button";
 import ButtonGroup from "@mui/joy/ButtonGroup";
 import { LeaderboardEntry, Side } from "./types";
+import { FREE_PRIMARY_COLOR, SHADOW_PRIMARY_COLOR } from "./styles/colors";
+import {
+    HEADER_HEIGHT_PX,
+    HEADER_MARGIN_PX,
+    TABLE_REFRESH_BTN_HEIGHT_PX,
+    TABLE_ELEMENTS_GAP,
+} from "./styles/sizes";
 import TableView from "./TableView";
 
 const DEFAULT_YEAR = 2024;
 const AVAILABLE_YEARS = [DEFAULT_YEAR, 2023];
 const COMING_SOON_YEARS = [2022];
+
+const YEAR_SELECTOR_HEIGHT = 36;
+const HEADER_ROW_HEIGHT = 32;
+
+const TABLE_TOP_POSITION =
+    HEADER_HEIGHT_PX +
+    HEADER_MARGIN_PX +
+    YEAR_SELECTOR_HEIGHT +
+    TABLE_REFRESH_BTN_HEIGHT_PX +
+    TABLE_ELEMENTS_GAP * 2;
 
 function Rankings() {
     const [entries, setEntries] = useState<LeaderboardEntry[]>([]);
@@ -48,7 +65,7 @@ function Rankings() {
                     width: "100%",
                 }}
             >
-                <ButtonGroup>
+                <ButtonGroup style={{ height: `${YEAR_SELECTOR_HEIGHT}px` }}>
                     {AVAILABLE_YEARS.map((yearOption) => (
                         <Button
                             key={yearOption}
@@ -75,55 +92,85 @@ function Rankings() {
                 error={error}
                 loading={loading}
                 label="Rankings"
+                containerStyle={{
+                    maxHeight: `calc(100vh - ${TABLE_TOP_POSITION}px - ${TABLE_ELEMENTS_GAP}px)`,
+                }}
                 header={
                     <>
-                        <tr>
-                            <TableHeader rowSpan={3}>Rank</TableHeader>
-                            <TableHeader rowSpan={2} colSpan={2}>
+                        <TableHeaderRow>
+                            <TableHeaderCell level={0} rowSpan={3}>
+                                Rank
+                            </TableHeaderCell>
+                            <TableHeaderCell level={0} rowSpan={2} colSpan={2}>
                                 Player
-                            </TableHeader>
-                            <TableHeader
+                            </TableHeaderCell>
+                            <TableHeaderCell
+                                level={0}
                                 rowSpan={2}
                                 style={{ borderBottom: "none" }}
                             >
                                 Balanced
-                            </TableHeader>
-                            <TableHeader side="Shadow" rowSpan={3}>
+                            </TableHeaderCell>
+                            <TableHeaderCell
+                                level={0}
+                                side="Shadow"
+                                rowSpan={3}
+                            >
                                 Shadow Rating
-                            </TableHeader>
-                            <TableHeader side="Free" rowSpan={3}>
+                            </TableHeaderCell>
+                            <TableHeaderCell level={0} side="Free" rowSpan={3}>
                                 Free Rating
-                            </TableHeader>
-                            <TableHeader rowSpan={3}>Games</TableHeader>
-                            <TableHeader rowSpan={3}>Games {year}</TableHeader>
-                            <TableHeader colSpan={6}>
+                            </TableHeaderCell>
+                            <TableHeaderCell level={0} rowSpan={3}>
+                                Games
+                            </TableHeaderCell>
+                            <TableHeaderCell level={0} rowSpan={3}>
+                                Games {year}
+                            </TableHeaderCell>
+                            <TableHeaderCell level={0} colSpan={6}>
                                 Base Game {year}
-                            </TableHeader>
-                        </tr>
-                        <tr>
+                            </TableHeaderCell>
+                        </TableHeaderRow>
+
+                        <TableHeaderRow>
                             {/* Base */}
-                            <TableHeader side="Free" colSpan={3}>
+                            <TableHeaderCell level={1} side="Free" colSpan={3}>
                                 FP
-                            </TableHeader>
-                            <TableHeader side="Shadow" colSpan={3}>
+                            </TableHeaderCell>
+                            <TableHeaderCell
+                                level={1}
+                                side="Shadow"
+                                colSpan={3}
+                            >
                                 SP
-                            </TableHeader>
-                        </tr>
-                        <tr>
-                            <TableHeader>Country</TableHeader>
-                            <TableHeader>Name</TableHeader>
-                            <TableHeader>Avg. Rating</TableHeader>
+                            </TableHeaderCell>
+                        </TableHeaderRow>
+
+                        <TableHeaderRow>
+                            <TableHeaderCell level={2}>Country</TableHeaderCell>
+                            <TableHeaderCell level={2}>Name</TableHeaderCell>
+                            <TableHeaderCell level={2}>
+                                Avg. Rating
+                            </TableHeaderCell>
 
                             {/* FP Base */}
-                            <TableHeader side="Free">Win</TableHeader>
-                            <TableHeader side="Free">Loss</TableHeader>
-                            <TableHeader>%</TableHeader>
+                            <TableHeaderCell level={2} side="Free">
+                                Win
+                            </TableHeaderCell>
+                            <TableHeaderCell level={2} side="Free">
+                                Loss
+                            </TableHeaderCell>
+                            <TableHeaderCell level={2}>%</TableHeaderCell>
 
                             {/* SP Base */}
-                            <TableHeader side="Shadow">Win</TableHeader>
-                            <TableHeader side="Shadow">Loss</TableHeader>
-                            <TableHeader>%</TableHeader>
-                        </tr>
+                            <TableHeaderCell level={2} side="Shadow">
+                                Win
+                            </TableHeaderCell>
+                            <TableHeaderCell level={2} side="Shadow">
+                                Loss
+                            </TableHeaderCell>
+                            <TableHeaderCell level={2}>%</TableHeaderCell>
+                        </TableHeaderRow>
                     </>
                 }
                 body={entries.map((entry, i) => (
@@ -187,7 +234,9 @@ function TableCell({
                     ? {
                           ...style,
                           backgroundColor:
-                              side === "Shadow" ? "#990200" : "#0b5394",
+                              side === "Shadow"
+                                  ? SHADOW_PRIMARY_COLOR
+                                  : FREE_PRIMARY_COLOR,
                           color: "white",
                           opacity: light ? "60%" : "100%",
                       }
@@ -199,7 +248,16 @@ function TableCell({
     );
 }
 
-interface TableHeaderProps {
+interface TableHeaderRowProps {
+    children: ReactNode;
+}
+
+function TableHeaderRow({ children }: TableHeaderRowProps) {
+    return <tr style={{ height: `${HEADER_ROW_HEIGHT}px` }}>{children}</tr>;
+}
+
+interface TableHeaderCellProps {
+    level: number;
     children?: ReactNode;
     side?: Side;
     rowSpan?: number;
@@ -207,13 +265,14 @@ interface TableHeaderProps {
     style?: CSSProperties;
 }
 
-function TableHeader({
+function TableHeaderCell({
+    level,
     children,
     side,
     rowSpan,
     colSpan,
-    style = {},
-}: TableHeaderProps) {
+    style = { top: `${HEADER_ROW_HEIGHT * level}px` },
+}: TableHeaderCellProps) {
     return (
         <th
             rowSpan={rowSpan}
@@ -222,7 +281,10 @@ function TableHeader({
                 side
                     ? {
                           ...style,
-                          color: side === "Shadow" ? "#990200" : "#0b5394",
+                          color:
+                              side === "Shadow"
+                                  ? SHADOW_PRIMARY_COLOR
+                                  : FREE_PRIMARY_COLOR,
                       }
                     : style
             }

--- a/frontend/src/TableView.tsx
+++ b/frontend/src/TableView.tsx
@@ -1,8 +1,12 @@
-import React, { ReactNode } from "react";
+import React, { CSSProperties, ReactNode } from "react";
 import Box from "@mui/joy/Box";
 import Button from "@mui/joy/Button";
 import Table from "@mui/joy/Table";
 import Typography from "@mui/joy/Typography";
+import {
+    TABLE_REFRESH_BTN_HEIGHT_PX,
+    TABLE_ELEMENTS_GAP,
+} from "./styles/sizes";
 
 interface Props {
     refresh: () => void;
@@ -11,6 +15,7 @@ interface Props {
     label: string;
     header: ReactNode;
     body: ReactNode;
+    containerStyle?: CSSProperties;
 }
 
 export default function TableView({
@@ -20,14 +25,15 @@ export default function TableView({
     label,
     header,
     body,
+    containerStyle = {},
 }: Props) {
     return (
         <Box
             sx={{
                 display: "flex",
                 flexDirection: "column",
-                gap: 2,
-                m: 2,
+                mx: 2,
+                mb: `${TABLE_ELEMENTS_GAP}px`,
             }}
         >
             <Box
@@ -36,9 +42,15 @@ export default function TableView({
                     width: "100%",
                     alignItems: "center",
                     justifyContent: "center",
+                    margin: `${TABLE_ELEMENTS_GAP}px 0`,
                 }}
             >
-                <Button onClick={refresh}>Refresh</Button>
+                <Button
+                    onClick={refresh}
+                    sx={{ height: `${TABLE_REFRESH_BTN_HEIGHT_PX}px` }}
+                >
+                    Refresh
+                </Button>
             </Box>
 
             {error && <Typography color="danger">{error}</Typography>}
@@ -51,6 +63,7 @@ export default function TableView({
                         overflow: "auto",
                         boxShadow: "lg",
                         borderRadius: "sm",
+                        ...containerStyle,
                     }}
                 >
                     <Table

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { createRoot } from "react-dom/client";
 import App from "./App";
-import "./index.css";
+import "./styles/index.css";
 
 const container = document.getElementById("root");
 

--- a/frontend/src/styles/colors.ts
+++ b/frontend/src/styles/colors.ts
@@ -1,0 +1,3 @@
+export const SHADOW_PRIMARY_COLOR = "#990200";
+export const FREE_PRIMARY_COLOR = "#0b5394";
+export const FREE_ACCENT_COLOR = "#3f99ff";

--- a/frontend/src/styles/sizes.ts
+++ b/frontend/src/styles/sizes.ts
@@ -1,0 +1,4 @@
+export const HEADER_HEIGHT_PX = 44;
+export const HEADER_MARGIN_PX = 20;
+export const TABLE_REFRESH_BTN_HEIGHT_PX = 36;
+export const TABLE_ELEMENTS_GAP = 16;


### PR DESCRIPTION
- Changes certain elements which don't need to responsively resize (header, the ladder year selector, and the "refresh" button above tables) to have fixed heights, in order to responsively limit the ladder and game report tables to fit the remaining vertical screen space
- Pins row headers, which was enabled by bounding the table height
  - The table `stickyHeader` prop only works on 2 levels of row headers before throwing up its hands and giving up, so I had to do a funky workaround to make all 3 row header levels of the ladder table sticky
- Adds a `styles` directory so there was a good place to keep the fixed heights required for these changes (in `sizes.ts`), and a little bit of scope creep to throw a `colors.ts` in the same place, so we can have common color palette to pull from