### PR TITLE
Auto-complete player names in game report form

### DIFF
--- a/frontend/src/Autocomplete.tsx
+++ b/frontend/src/Autocomplete.tsx
@@ -1,0 +1,59 @@
+import React, { ReactNode, useState } from "react";
+import Alert from "@mui/joy/Alert";
+import Box from "@mui/joy/Box";
+import MaterialAutocomplete from "@mui/joy/Autocomplete";
+import CircularProgress from "@mui/joy/CircularProgress";
+
+interface Props {
+    options: string[]; // could update to allow objects: https://mui.com/joy-ui/react-autocomplete/
+    current: string;
+    placeholder: string;
+    loading: boolean;
+    alertText?: string;
+    onChange: (value: string) => void;
+    validate: () => void;
+}
+
+export default function Autocomplete({
+    options,
+    current,
+    placeholder,
+    loading,
+    alertText,
+    onChange,
+    validate,
+}: Props) {
+    const [displayedAlertText, setDisplayedAlertText] =
+        useState<ReactNode>(null);
+
+    return (
+        <Box>
+            {displayedAlertText && (
+                <Alert color="warning" sx={{ mb: "10px" }}>
+                    {displayedAlertText}
+                </Alert>
+            )}
+
+            <MaterialAutocomplete
+                clearOnEscape
+                freeSolo
+                openOnFocus
+                options={options}
+                inputValue={current}
+                placeholder={placeholder}
+                onInputChange={(_, value) => onChange(value)}
+                onChange={(_, value) => {
+                    if (value) setDisplayedAlertText(null);
+                }}
+                onBlur={() => {
+                    validate();
+                    setDisplayedAlertText(alertText);
+                }}
+                disabled={loading}
+                startDecorator={
+                    loading ? <CircularProgress size="sm" /> : undefined
+                }
+            />
+        </Box>
+    );
+}

--- a/frontend/src/GameReportForm.tsx
+++ b/frontend/src/GameReportForm.tsx
@@ -9,6 +9,7 @@ import Sheet from "@mui/joy/Sheet";
 import Button from "@mui/joy/Button";
 import {
     competitionTypes,
+    ErrorMessage,
     expansions,
     leagues,
     matchTypes,
@@ -24,6 +25,7 @@ import {
     strongholdSide,
 } from "./utils";
 import useFormData from "./hooks/useFormData";
+import Autocomplete from "./Autocomplete";
 import GameReportFormElement from "./GameReportFormElement";
 import MultiOptionInput from "./MultiOptionInput";
 import SelectNumericOptionInput from "./SelectNumericOptionInput";
@@ -34,7 +36,7 @@ import VictoryPoints from "./VictoryPoints";
 function GameReportForm() {
     const [
         formData,
-        { errorOnSubmit, successMessage, loading },
+        { errorOnSubmit, successMessage, loading, loadingPlayers, playerNames },
         {
             handleInputChange,
             validateField,
@@ -89,8 +91,16 @@ function GameReportForm() {
                 label={"Who won?"}
                 error={formData.winner.error}
             >
-                <TextInput
-                    value={formData.winner.value || ""}
+                <Autocomplete
+                    options={playerNames}
+                    current={formData.winner.value || ""}
+                    loading={loadingPlayers}
+                    alertText={
+                        !!formData.winner.value &&
+                        !playerNames.includes(formData.winner.value)
+                            ? ErrorMessage.MissingPlayerName
+                            : ""
+                    }
                     placeholder="Player Name - Please check spelling!"
                     onChange={handleInputChange("winner")}
                     validate={validateField("winner")}
@@ -100,8 +110,16 @@ function GameReportForm() {
                 label={"Who lost?"}
                 error={formData.loser.error}
             >
-                <TextInput
-                    value={formData.loser.value || ""}
+                <Autocomplete
+                    options={playerNames}
+                    current={formData.loser.value || ""}
+                    loading={loadingPlayers}
+                    alertText={
+                        !!formData.loser.value &&
+                        !playerNames.includes(formData.loser.value)
+                            ? ErrorMessage.MissingPlayerName
+                            : ""
+                    }
                     placeholder="Player Name - Please check spelling!"
                     onChange={handleInputChange("loser")}
                     validate={validateField("loser")}

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -102,6 +102,7 @@ export const serverValidationErrors = [
 export enum ErrorMessage {
     Required = "Required",
     OnSubmit = "Could not submit, please resolve errors",
+    MissingPlayerName = "This player does not exist in the database. Unless it's a new player, please check the spelling.",
 }
 
 export const INFINITE = 100;

--- a/frontend/src/hooks/useFormData/index.tsx
+++ b/frontend/src/hooks/useFormData/index.tsx
@@ -5,6 +5,7 @@ import {
     FieldError,
     FormData,
     GameReportPayload,
+    LeaderboardEntry,
     ServerErrorBody,
     ServerValidationError,
     Stronghold,
@@ -37,13 +38,17 @@ type Meta = {
     errorOnSubmit: FieldError;
     successMessage: SuccessMessage;
     loading: boolean;
+    playerNames: string[];
+    loadingPlayers: boolean;
 };
 
 const useFormData = (): [FormData, Meta, Helpers] => {
     const [formData, setFormData] = useState(initialFormData);
+    const [playerNames, setPlayerNames] = useState<string[]>([]);
     const [errorOnSubmit, setErrorOnSubmit] = useState<FieldError>(null);
     const [successMessage, setSuccessMessage] = useState<SuccessMessage>(null);
     const [loading, setLoading] = useState(false);
+    const [loadingPlayers, setLoadingPlayers] = useState(false);
 
     const handleInputChange = <K extends keyof FormData>(field: K) => {
         return (value: FormData[K]["value"]) =>
@@ -180,6 +185,27 @@ const useFormData = (): [FormData, Meta, Helpers] => {
         }, [controlCondition]);
     };
 
+    useEffect(function loadPlayerNames() {
+        setLoadingPlayers(true);
+
+        axios
+            .get(
+                "https://api.waroftheringcommunity.net:8080/leaderboard",
+                { params: { year: 2024 } } // :'D
+            )
+            .then((response) => {
+                setPlayerNames(
+                    (response.data.entries as LeaderboardEntry[]).map(
+                        (entry) => entry.name
+                    )
+                );
+            })
+            .catch((error) => console.error(error))
+            .finally(() => {
+                setLoadingPlayers(false);
+            });
+    }, []);
+
     useEffect(
         function resetForm() {
             if (successMessage) setFormData(initialFormData);
@@ -223,7 +249,7 @@ const useFormData = (): [FormData, Meta, Helpers] => {
 
     return [
         formData,
-        { errorOnSubmit, successMessage, loading },
+        { errorOnSubmit, successMessage, loading, loadingPlayers, playerNames },
         {
             handleInputChange,
             validateField,

--- a/frontend/src/hooks/useFormData/index.tsx
+++ b/frontend/src/hooks/useFormData/index.tsx
@@ -200,7 +200,7 @@ const useFormData = (): [FormData, Meta, Helpers] => {
                     )
                 );
             })
-            .catch((error) => console.error(error))
+            .catch(console.error)
             .finally(() => {
                 setLoadingPlayers(false);
             });


### PR DESCRIPTION
Converts player name fields into `Autocomplete`s, and displays a warning message above each one if you type a name that isn't present ✨

The player names are kind of mocked up, they're being retrieved from the `/leaderboard` endpoint with 2024 hard-coded just to have a substantial list of names displaying.

A good way to handle new players when there's time would be a `+ add new player` option inside the autocomplete, which would bring up a popup form to create a new player, and would send a POST request to a `/player` endpoint or something like that; then the new player would be merged into the `Autocomplete` options. After that we could add validation that player names MUST exist before submitting the form.