### PR TITLE
Show nice display names

### DIFF
--- a/backend/src/Types/Api.hs
+++ b/backend/src/Types/Api.hs
@@ -91,9 +91,9 @@ fromGameReport (Entity rid r, Entity _ winner, Entity _ loser) =
     { rid,
       timestamp = r.gameReportTimestamp,
       winnerId = r.gameReportWinnerId,
-      winner = winner.playerName,
+      winner = winner.playerDisplayName,
       loserId = r.gameReportLoserId,
-      loser = loser.playerName,
+      loser = loser.playerDisplayName,
       side = r.gameReportSide,
       victory = r.gameReportVictory,
       match = r.gameReportMatch,
@@ -151,7 +151,7 @@ fromPlayerStats :: (Entity Player, PlayerStats) -> LeaderboardEntry
 fromPlayerStats (Entity pid p, (t, y)) =
   LeaderboardEntry
     { pid,
-      name = p.playerName,
+      name = p.playerDisplayName,
       country = p.playerCountry,
       currentRatingFree = t.playerStatsTotalRatingFree,
       currentRatingShadow = t.playerStatsTotalRatingShadow,


### PR DESCRIPTION
![](https://media.giphy.com/media/NXISPTBIPRo6of0rZx/giphy.gif?cid=790b76112brgnjcubfpaldsmlsx8a90uwwipka1jpn7ylet6&ep=v1_gifs_search&rid=giphy.gif&ct=g)

Does what it says. A display name is set the first time a player is inserted into the database. This is sourced from either the 2022 data (if they existed then) or otherwise from however the first person to report it types it.

Since folks don't always report their own name (e.g. if they lose their first game), this is why it can be nice to allow admin-renaming. Coming soon!