### PR TITLE
Update active status when reprocessing reports

### DIFF
--- a/backend/src/AppServer.hs
+++ b/backend/src/AppServer.hs
@@ -21,6 +21,7 @@ import Database
     repsertPlayerStats,
     resetStats,
     runDb,
+    updateActiveStatus,
     updatePlayerName,
     updateReports,
   )
@@ -159,6 +160,7 @@ reprocessReports = do
   resetStats
   reports <- getAllGameReports
   forM_ (reverse reports) processReport
+  updateActiveStatus
 
 submitReportHandler :: RawGameReport -> AppM SubmitGameReportResponse
 submitReportHandler rawReport = case validateReport rawReport of

--- a/backend/src/Database.hs
+++ b/backend/src/Database.hs
@@ -132,7 +132,7 @@ insertPlayerIfNotExists name = do
     Just p -> pure p
     Nothing -> lift $ do
       logInfoN $ "Adding new player " <> normalizeName name <> " to database."
-      let p = Player (normalizeName name) name Nothing
+      let p = Player (normalizeName name) name Nothing False
       pid <- insert p
       pure $ Entity pid p
 

--- a/backend/src/Database.hs
+++ b/backend/src/Database.hs
@@ -205,7 +205,9 @@ updateActiveStatus = do
       subSelectCount $ do
         report <- from $ table @GameReport
         where_
-          ( ((report ^. GameReportWinnerId ==. player ^. PlayerId) ||. (report ^. GameReportLoserId ==. player ^. PlayerId))
+          ( ( (report ^. GameReportWinnerId ==. player ^. PlayerId)
+                ||. (report ^. GameReportLoserId ==. player ^. PlayerId)
+            )
               &&. report ^. GameReportTimestamp >=. val cutoffDay
           )
 

--- a/backend/src/Database.hs
+++ b/backend/src/Database.hs
@@ -3,6 +3,7 @@ module Database where
 import AppConfig (AppM, Env (..), runAppLogger)
 import Control.Monad.Logger (LoggingT, MonadLogger, logInfoN)
 import Data.Text qualified as T
+import Data.Time (addUTCTime, getCurrentTime, nominalDay)
 import Database.Esqueleto.Experimental
   ( Entity (..),
     From,
@@ -26,6 +27,7 @@ import Database.Esqueleto.Experimental
     select,
     selectOne,
     set,
+    subSelectCount,
     table,
     then_,
     update,
@@ -33,10 +35,13 @@ import Database.Esqueleto.Experimental
     when_,
     where_,
     (&&.),
+    (<.),
     (=.),
     (==.),
+    (>=.),
     (?.),
     (^.),
+    (||.),
     type (:&) (..),
   )
 import Servant (ServerError, throwError)
@@ -180,6 +185,29 @@ updateReports fromPid toPid = lift $ do
             [when_ (report ^. GameReportLoserId ==. val fromPid) then_ (val toPid)]
             (else_ (report ^. GameReportLoserId))
       ]
+
+updateActiveStatus :: (MonadIO m, MonadLogger m) => DBAction m ()
+updateActiveStatus = do
+  now <- liftIO getCurrentTime
+  let cutoffDay = addUTCTime (negate $ 365 * nominalDay) now
+  let activeRequirement = 4 :: Int
+
+  lift $ update $ \player -> do
+    set
+      player
+      [ PlayerIsActive
+          =. case_
+            [when_ (countReports player cutoffDay <. val activeRequirement) then_ (val False)]
+            (else_ val True)
+      ]
+  where
+    countReports player cutoffDay =
+      subSelectCount $ do
+        report <- from $ table @GameReport
+        where_
+          ( ((report ^. GameReportWinnerId ==. player ^. PlayerId) ||. (report ^. GameReportLoserId ==. player ^. PlayerId))
+              &&. report ^. GameReportTimestamp >=. val cutoffDay
+          )
 
 deletePlayer :: (MonadIO m, MonadLogger m) => PlayerId -> DBAction m ()
 deletePlayer pid = lift $ do

--- a/backend/src/Types/Api.hs
+++ b/backend/src/Types/Api.hs
@@ -130,6 +130,7 @@ data LeaderboardEntry = LeaderboardEntry
   { pid :: PlayerId,
     name :: PlayerName,
     country :: Maybe Text,
+    isActive :: Bool,
     currentRatingFree :: Rating,
     currentRatingShadow :: Rating,
     averageRating :: Double,
@@ -153,6 +154,7 @@ fromPlayerStats (Entity pid p, (t, y)) =
     { pid,
       name = p.playerDisplayName,
       country = p.playerCountry,
+      isActive = p.playerIsActive,
       currentRatingFree = t.playerStatsTotalRatingFree,
       currentRatingShadow = t.playerStatsTotalRatingShadow,
       averageRating =

--- a/backend/src/Types/Database.hs
+++ b/backend/src/Types/Database.hs
@@ -15,6 +15,7 @@ share
     name PlayerName
     displayName PlayerName
     country Text Maybe
+    isActive Bool
     UniquePlayerName name
     UniquePlayerDisplayName name
     deriving Show


### PR DESCRIPTION
![](https://media.giphy.com/media/O56mFaY98zYrdJsKaX/giphy.gif?cid=ecf05e47fm45hlgyevl5vp6qxmpr1w5oidfhcvjp9u9fbibs&ep=v1_gifs_search&rid=giphy.gif&ct=g)

A little jank, perhaps, but I think a reasonable middle ground to start with. This adds `isActive` to the leaderboard response, and provides a database function for updating the active status across the whole table. This only runs when reports are reprocessed.

I figure that's okay for MVP, since reports are reprocessed during migration. But eventually we may want to play around with scheduling this, or doing an update check for the involved players when a report is submitted.