### PR TITLE
Refactor useFormData hook to accept generic form data

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,12 +17,13 @@ import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import Typography from "@mui/joy/Typography";
 import { BrowserRouter, Routes, Route, Link } from "react-router-dom";
 import { HEADER_HEIGHT_PX, HEADER_MARGIN_PX } from "./styles/sizes";
-import { Year, LeaderboardEntry } from "./types";
-import { DEFAULT_YEAR } from "./constants";
+import { LeaderboardEntry } from "./types";
 
 export default function App() {
     const [leaderboard, setLeaderboard] = useState<LeaderboardEntry[]>([]);
-    const [leaderboardYear, setLeaderboardYear] = useState<Year>(DEFAULT_YEAR);
+    const [leaderboardYear, setLeaderboardYear] = useState(
+        new Date().getFullYear()
+    );
     const [loadingLeaderboard, setLoadingLeaderboard] = useState(false);
 
     const getLeaderboard = () => {

--- a/frontend/src/Rankings.tsx
+++ b/frontend/src/Rankings.tsx
@@ -2,8 +2,7 @@ import React, { CSSProperties, ReactNode, useState } from "react";
 import Box from "@mui/joy/Box";
 import Button from "@mui/joy/Button";
 import ButtonGroup from "@mui/joy/ButtonGroup";
-import { LeaderboardEntry, Side, Year } from "./types";
-import { availableYears } from "./constants";
+import { LeaderboardEntry, Side } from "./types";
 import { FREE_PRIMARY_COLOR, SHADOW_PRIMARY_COLOR } from "./styles/colors";
 import {
     HEADER_HEIGHT_PX,
@@ -12,13 +11,15 @@ import {
     TABLE_ELEMENTS_GAP,
 } from "./styles/sizes";
 import TableView from "./TableView";
+import { range } from "./utils";
+import { START_YEAR } from "./constants";
 
 interface Props {
     leaderboard: LeaderboardEntry[];
-    year: Year;
+    year: number;
     loading: boolean;
     getLeaderboard: () => void;
-    setYear: (year: Year) => void;
+    setYear: (year: number) => void;
 }
 
 const YEAR_SELECTOR_HEIGHT = 36;
@@ -45,6 +46,8 @@ function Rankings({
         getLeaderboard();
     };
 
+    const availableYears = range(START_YEAR, new Date().getFullYear() + 1);
+
     return (
         <Box>
             <Box
@@ -55,7 +58,7 @@ function Rankings({
                 }}
             >
                 <ButtonGroup style={{ height: `${YEAR_SELECTOR_HEIGHT}px` }}>
-                    {availableYears.map((yearOption) => (
+                    {availableYears.reverse().map((yearOption) => (
                         <Button
                             key={yearOption}
                             variant="plain"

--- a/frontend/src/Rankings.tsx
+++ b/frontend/src/Rankings.tsx
@@ -1,9 +1,9 @@
-import axios from "axios";
-import React, { CSSProperties, ReactNode, useEffect, useState } from "react";
+import React, { CSSProperties, ReactNode, useState } from "react";
 import Box from "@mui/joy/Box";
 import Button from "@mui/joy/Button";
 import ButtonGroup from "@mui/joy/ButtonGroup";
-import { LeaderboardEntry, Side } from "./types";
+import { LeaderboardEntry, Side, Year } from "./types";
+import { availableYears } from "./constants";
 import { FREE_PRIMARY_COLOR, SHADOW_PRIMARY_COLOR } from "./styles/colors";
 import {
     HEADER_HEIGHT_PX,
@@ -13,9 +13,13 @@ import {
 } from "./styles/sizes";
 import TableView from "./TableView";
 
-const DEFAULT_YEAR = 2024;
-const AVAILABLE_YEARS = [DEFAULT_YEAR, 2023];
-const COMING_SOON_YEARS = [2022];
+interface Props {
+    leaderboard: LeaderboardEntry[];
+    year: Year;
+    loading: boolean;
+    getLeaderboard: () => void;
+    setYear: (year: Year) => void;
+}
 
 const YEAR_SELECTOR_HEIGHT = 36;
 const HEADER_ROW_HEIGHT = 32;
@@ -27,34 +31,19 @@ const TABLE_TOP_POSITION =
     TABLE_REFRESH_BTN_HEIGHT_PX +
     TABLE_ELEMENTS_GAP * 2;
 
-function Rankings() {
-    const [entries, setEntries] = useState<LeaderboardEntry[]>([]);
-    const [loading, setLoading] = useState(false);
+function Rankings({
+    leaderboard,
+    year,
+    loading,
+    getLeaderboard,
+    setYear,
+}: Props) {
     const [error, setError] = useState<string | null>(null);
-    const [year, setYear] = useState(DEFAULT_YEAR);
-
-    const getLeaderboard = async () => {
-        try {
-            const response = await axios.get(
-                // "http://localhost:8081/leaderboard"
-                "https://api.waroftheringcommunity.net:8080/leaderboard",
-                { params: { year } }
-            );
-            setEntries(response.data.entries);
-        } catch (error) {
-            setError("Something went wrong");
-            console.error(error);
-        }
-        setLoading(false);
-    };
 
     const refresh = () => {
         setError(null);
-        setLoading(true);
         getLeaderboard();
     };
-
-    useEffect(refresh, [year]);
 
     return (
         <Box>
@@ -66,7 +55,7 @@ function Rankings() {
                 }}
             >
                 <ButtonGroup style={{ height: `${YEAR_SELECTOR_HEIGHT}px` }}>
-                    {AVAILABLE_YEARS.map((yearOption) => (
+                    {availableYears.map((yearOption) => (
                         <Button
                             key={yearOption}
                             variant="plain"
@@ -76,11 +65,6 @@ function Rankings() {
                                     year === yearOption ? "bold" : "normal",
                             }}
                         >
-                            {yearOption}
-                        </Button>
-                    ))}
-                    {COMING_SOON_YEARS.map((yearOption) => (
-                        <Button key={yearOption} disabled variant="plain">
                             {yearOption}
                         </Button>
                     ))}
@@ -173,7 +157,7 @@ function Rankings() {
                         </TableHeaderRow>
                     </>
                 }
-                body={entries.map((entry, i) => (
+                body={leaderboard.map((entry, i) => (
                     <tr key={entry.pid}>
                         <TableCell>{i + 1}</TableCell>
                         <TableCell>{entry.country}</TableCell>

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -106,3 +106,5 @@ export enum ErrorMessage {
 }
 
 export const INFINITE = 100;
+export const DEFAULT_YEAR = 2024;
+export const availableYears = [DEFAULT_YEAR, 2023, 2022] as const;

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -106,5 +106,4 @@ export enum ErrorMessage {
 }
 
 export const INFINITE = 100;
-export const DEFAULT_YEAR = 2024;
-export const availableYears = [DEFAULT_YEAR, 2023, 2022] as const;
+export const START_YEAR = 2023;

--- a/frontend/src/hooks/useFormData/index.tsx
+++ b/frontend/src/hooks/useFormData/index.tsx
@@ -1,70 +1,69 @@
-import axios from "axios";
-import { useEffect, useState } from "react";
+import { Dispatch, SetStateAction, useState } from "react";
 import {
-    Expansion,
+    ConstrainedFormData,
     FieldError,
-    FormData,
-    GameReportPayload,
-    LeaderboardEntry,
     ServerErrorBody,
-    ServerValidationError,
-    Stronghold,
     SuccessMessage,
-    ValidFormData,
-    ValueOf,
 } from "../../types";
-import {
-    ErrorMessage,
-    optionalFields,
-    serverValidationErrors,
-    strongholds,
-} from "../../constants";
-import initialFormData from "./initialFormData";
+import { ErrorMessage } from "../../constants";
+import { isServerError, objectKeys } from "../../utils";
 
-type Helpers = {
-    handleInputChange: <K extends keyof FormData>(
+type Helpers<F> = {
+    setFormData: Dispatch<SetStateAction<ConstrainedFormData<F>>>;
+    handleInputChange: <K extends keyof F>(
         field: K
-    ) => (value: FormData[K]["value"]) => void;
-    validateField: <K extends keyof FormData>(field: K) => () => void;
+    ) => (value: ConstrainedFormData<F>[K]["value"]) => void;
+    validateField: <K extends keyof F>(field: K) => () => void;
     handleSubmit: () => Promise<void>;
     setSuccessMessage: (message: SuccessMessage) => void;
-    isStrongholdInPlay: (
-        expansions: Expansion[],
-        stronghold: Stronghold
-    ) => boolean;
 };
 
 type Meta = {
     errorOnSubmit: FieldError;
     successMessage: SuccessMessage;
     loading: boolean;
-    playerNames: string[];
-    loadingPlayers: boolean;
 };
 
-const useFormData = (): [FormData, Meta, Helpers] => {
-    const [formData, setFormData] = useState(initialFormData);
-    const [playerNames, setPlayerNames] = useState<string[]>([]);
+interface Args<F, V> {
+    initialFormData: ConstrainedFormData<F>;
+    optionalFields: string[];
+    missingFieldErrorMessage?: ErrorMessage;
+    submit: (validatedFormData: ConstrainedFormData<V>) => Promise<any>; // FIXME
+    toErrorMessage: (error: ServerErrorBody) => string;
+}
+
+export default function useFormData<F, V extends F>({
+    initialFormData,
+    optionalFields,
+    missingFieldErrorMessage = ErrorMessage.Required,
+    submit,
+    toErrorMessage,
+}: Args<F, V>): [ConstrainedFormData<F>, Meta, Helpers<F>] {
+    const [formData, setFormData] =
+        useState<ConstrainedFormData<F>>(initialFormData);
     const [errorOnSubmit, setErrorOnSubmit] = useState<FieldError>(null);
     const [successMessage, setSuccessMessage] = useState<SuccessMessage>(null);
     const [loading, setLoading] = useState(false);
-    const [loadingPlayers, setLoadingPlayers] = useState(false);
 
-    const handleInputChange = <K extends keyof FormData>(field: K) => {
-        return (value: FormData[K]["value"]) =>
+    const handleInputChange = <K extends keyof ConstrainedFormData<F>>(
+        field: K
+    ) => {
+        return (value: ConstrainedFormData<F>[K]["value"]) =>
             setFormData((prevData) => ({
                 ...prevData,
                 [field]: { ...prevData[field], value },
             }));
     };
 
-    const validateField = <K extends keyof FormData>(field: K) => {
+    const validateField = <K extends keyof ConstrainedFormData<F>>(
+        field: K
+    ) => {
         return () => {
             setFormData((prevData) => {
                 const error: FieldError =
                     prevData[field].validate() ||
-                    (isFieldMissing(field, prevData) &&
-                        ErrorMessage.Required) ||
+                    (isFieldMissing(field, prevData, optionalFields) &&
+                        missingFieldErrorMessage) ||
                     null;
 
                 return error || prevData[field].error
@@ -77,13 +76,13 @@ const useFormData = (): [FormData, Meta, Helpers] => {
         };
     };
 
-    const validateForm = (): ValidFormData | ErrorMessage.OnSubmit => {
+    const validateForm = (): ConstrainedFormData<V> | ErrorMessage.OnSubmit => {
         const stateUpdates = objectKeys(formData).reduce<(() => void)[]>(
             (updates, field) => {
                 const error: FieldError =
                     formData[field].validate() ||
-                    (isFieldMissing(field, formData) &&
-                        ErrorMessage.Required) ||
+                    (isFieldMissing(field, formData, optionalFields) &&
+                        missingFieldErrorMessage) ||
                     null;
 
                 if (error) {
@@ -101,7 +100,7 @@ const useFormData = (): [FormData, Meta, Helpers] => {
         );
 
         if (!stateUpdates.length) {
-            return formData as ValidFormData;
+            return formData as ConstrainedFormData<V>;
         } else {
             stateUpdates.forEach((update) => update());
             return ErrorMessage.OnSubmit;
@@ -113,21 +112,12 @@ const useFormData = (): [FormData, Meta, Helpers] => {
             const validatedResult = validateForm();
 
             if (validatedResult === ErrorMessage.OnSubmit) {
-                setErrorOnSubmit(validatedResult);
+                setErrorOnSubmit(validatedResult as ErrorMessage.OnSubmit);
             } else {
                 setErrorOnSubmit(null);
                 setLoading(true);
 
-                const response = await axios.post(
-                    //"http://localhost:8081/submitReport",
-                    "https://api.waroftheringcommunity.net:8080/submitReport",
-                    toPayload(validatedResult),
-                    {
-                        headers: {
-                            "Content-Type": "application/json",
-                        },
-                    }
-                );
+                const response = await submit(validatedResult);
 
                 console.log("Form submitted successfully:", response);
                 // Handle the response data as needed
@@ -145,124 +135,28 @@ const useFormData = (): [FormData, Meta, Helpers] => {
         setLoading(false);
     };
 
-    const useControlledClearEffect = <
-        K extends keyof FormData,
-        V extends ValueOf<FormData>["value"]
-    >(
-        controlField: V,
-        clearField: K,
-        controlCondition?: (value: V) => boolean
-    ) => {
-        const condition = controlCondition
-            ? controlCondition(controlField)
-            : controlField;
-        useEffect(() => {
-            if (!condition) {
-                setFormData((formData) => ({
-                    ...formData,
-                    [clearField]: initialFormData[clearField],
-                }));
-            }
-        }, [controlField]);
-    };
-
-    const useStrongholdDeselectEffect = (
-        deselectedStronghold: Stronghold,
-        controlCondition: boolean
-    ) => {
-        useEffect(() => {
-            if (!controlCondition) {
-                setFormData((formData) => ({
-                    ...formData,
-                    strongholds: {
-                        ...formData.strongholds,
-                        value: formData.strongholds.value.filter(
-                            (stronghold) => stronghold !== deselectedStronghold
-                        ),
-                    },
-                }));
-            }
-        }, [controlCondition]);
-    };
-
-    useEffect(function loadPlayerNames() {
-        setLoadingPlayers(true);
-
-        axios
-            .get(
-                "https://api.waroftheringcommunity.net:8080/leaderboard",
-                { params: { year: 2024 } } // :'D
-            )
-            .then((response) => {
-                setPlayerNames(
-                    (response.data.entries as LeaderboardEntry[]).map(
-                        (entry) => entry.name
-                    )
-                );
-            })
-            .catch(console.error)
-            .finally(() => {
-                setLoadingPlayers(false);
-            });
-    }, []);
-
-    useEffect(
-        function resetForm() {
-            if (successMessage) setFormData(initialFormData);
-        },
-        [successMessage]
-    );
-
-    useControlledClearEffect(
-        formData.match.value,
-        "competition",
-        (match) => match === "Ranked"
-    );
-    useControlledClearEffect(
-        formData.match.value,
-        "league",
-        (match) => match === "Ranked"
-    );
-    useControlledClearEffect(
-        formData.competition.value,
-        "league",
-        (competition) => competition.includes("League")
-    );
-    useControlledClearEffect(
-        formData.expansions.value,
-        "treebeard",
-        (expansions) => expansions.includes("Treebeard")
-    );
-    useControlledClearEffect(formData.usedExpansions.value, "expansions");
-    useControlledClearEffect(formData.usedExpansions.value, "treebeard");
-    useControlledClearEffect(formData.usedHandicap.value, "actionTokens");
-    useControlledClearEffect(formData.usedHandicap.value, "dwarvenRings");
-    useControlledClearEffect(formData.didFellowshipReachMordor.value, "mordor");
-    useControlledClearEffect(formData.wasAragornCrowned.value, "aragornTurn");
-
-    strongholds.filter(isStrongholdConditional).map((stronghold) => {
-        useStrongholdDeselectEffect(
-            stronghold,
-            isStrongholdInPlay(formData.expansions.value, stronghold)
-        );
-    });
-
     return [
         formData,
-        { errorOnSubmit, successMessage, loading, loadingPlayers, playerNames },
         {
+            errorOnSubmit,
+            successMessage,
+            loading,
+        },
+        {
+            setFormData,
             handleInputChange,
             validateField,
             handleSubmit,
-            isStrongholdInPlay,
             setSuccessMessage,
         },
     ];
-};
+}
 
-export default useFormData;
-
-function isFieldMissing(field: keyof FormData, formData: FormData) {
+function isFieldMissing<F>(
+    field: keyof ConstrainedFormData<F>,
+    formData: ConstrainedFormData<F>,
+    optionalFields: string[]
+) {
     const { value } = formData[field];
     const isRequired = optionalFields.every((opF) => opF !== field);
     const isEmpty =
@@ -271,161 +165,4 @@ function isFieldMissing(field: keyof FormData, formData: FormData) {
         value === "" ||
         (Array.isArray(value) && !value.length);
     return isEmpty && isRequired;
-}
-
-function toPayload(formData: ValidFormData): GameReportPayload {
-    return {
-        winner: formData.winner.value,
-        loser: formData.loser.value,
-        side: formData.side.value,
-        victory: formData.victory.value,
-        match: formData.match.value,
-        competition: formData.competition.value,
-        league: formData.league.value,
-        expansions: formData.expansions.value,
-        treebeard: formData.treebeard.value,
-        actionTokens: formData.actionTokens.value,
-        dwarvenRings: formData.dwarvenRings.value,
-        turns: formData.turns.value,
-        corruption: formData.corruption.value,
-        mordor: formData.mordor.value,
-        initialEyes: formData.initialEyes.value,
-        aragornTurn: formData.aragornTurn.value,
-        strongholds: formData.strongholds.value,
-        interestRating: formData.interestRating.value,
-        comment: formData.comment.value,
-    };
-}
-
-function isStrongholdInPlay(
-    expansions: Expansion[],
-    stronghold: Stronghold
-): boolean {
-    switch (stronghold) {
-        case "EredLuin":
-            return expansions.includes("Cities");
-        case "SouthRhun":
-            return expansions.includes("Cities");
-        case "IronHills":
-            return expansions.includes("FateOfErebor");
-        case "Shire":
-        case "Edoras":
-        case "Dale":
-        case "Pelargir":
-        case "Rivendell":
-        case "GreyHavens":
-        case "HelmsDeep":
-        case "Lorien":
-        case "WoodlandRealm":
-        case "MinasTirith":
-        case "DolAmroth":
-        case "Erebor":
-        case "Angmar":
-        case "FarHarad":
-        case "MountGundabad":
-        case "Moria":
-        case "DolGuldur":
-        case "Orthanc":
-        case "Morannon":
-        case "BaradDur":
-        case "MinasMorgul":
-        case "Umbar":
-            return true;
-    }
-}
-
-function isStrongholdConditional(stronghold: Stronghold): boolean {
-    return !isStrongholdInPlay([], stronghold);
-}
-
-function objectKeys<T extends object>(obj: T): Array<keyof T> {
-    return Object.keys(obj) as Array<keyof T>;
-}
-
-function isServerError(error: unknown): error is ServerErrorBody {
-    return (
-        typeof error === "object" &&
-        error !== null &&
-        "status" in error &&
-        typeof error.status === "number" &&
-        "response" in error &&
-        typeof error.response === "object" &&
-        error.response !== null &&
-        "data" in error.response &&
-        typeof error.response.data === "string"
-    );
-}
-
-function toErrorMessage(error: ServerErrorBody): string {
-    if (error.status === 422) {
-        const parsedResult = parseValidationResult(error.response.data);
-        if (parsedResult.length) {
-            const errorMessage = parsedResult
-                .map(validationErrorToMessage)
-                .join(", ");
-            return (
-                errorMessage.slice(0, 1).toUpperCase() + errorMessage.slice(1)
-            );
-        }
-    }
-    return "Something went wrong.";
-}
-
-function parseValidationResult(
-    serverValidationResult: string
-): ServerValidationError[] {
-    const parsedResult = serverValidationResult
-        .slice(1, serverValidationResult.length - 1)
-        .split(",");
-
-    return parsedResult.every((error) =>
-        serverValidationErrors.includes(error as ServerValidationError)
-    )
-        ? (parsedResult as ServerValidationError[])
-        : [];
-}
-
-function validationErrorToMessage(
-    validationError: ServerValidationError
-): string {
-    switch (validationError) {
-        case "VictoryConditionConflictSPRV":
-            return "conditions met for Shadow ring victory instead of selected victory type";
-        case "VictoryConditionConflictFPRV":
-            return "conditions met for Free Peoples ring victory instead of selected victory type";
-        case "VictoryConditionConflictSPMV":
-            return "conditions met for Shadow military victory instead of selected victory type";
-        case "VictoryConditionConflictFPMV":
-            return "conditions met for Free Peoples military victory instead of selected victory type";
-        case "VictoryConditionConflictConcession":
-            return "conditions met for Concession victory type instead of selected victory type";
-        case "NoVictoryConditionMet":
-            return "no victory conditions met";
-        case "InvalidSPMV":
-            return "invalid Shadow military victory";
-        case "InvalidFPMV":
-            return "invalid Free Peoples military victory";
-        case "InvalidSPRV":
-            return "invalid Shadow ring victory";
-        case "InvalidFPRV":
-            return "invalid Free Peoples ring victory";
-        case "CompetitionMismatch":
-            return "reported competition type does not match reported league";
-        case "LeagueExpansionMismatch":
-            return "reported league does not match reported expansions";
-        case "TreebeardExpansionMismatch":
-            return "reported Treebeard muster does not match reported expansions";
-        case "TurnsOutOfRange":
-            return "invalid ending game turn selection";
-        case "CorruptionOutOfRange":
-            return "invalid fellowship corruption selection";
-        case "MordorOutOfRange":
-            return "invalid Mordor track selection";
-        case "InitialEyesOutOfRange":
-            return "invalid number of eyes allocated by Shadow on turn 1";
-        case "InterestRatingOutOfRange":
-            return "invalid interest rating selection";
-        case "InvalidStronghold":
-            return "invalid stronghold selections for the indicated expansions";
-    }
 }

--- a/frontend/src/hooks/useGameReportFormEffects.tsx
+++ b/frontend/src/hooks/useGameReportFormEffects.tsx
@@ -1,0 +1,103 @@
+import { useEffect } from "react";
+import { FormData, Stronghold, ValueOf } from "../types";
+import { strongholds } from "../constants";
+import { isStrongholdInPlay } from "../utils";
+
+interface Args {
+    formData: FormData;
+    initialFormData: FormData;
+    setFormData: React.Dispatch<React.SetStateAction<FormData>>;
+    successMessage: string | null;
+}
+
+export default function useGameReportClearEffects({
+    formData,
+    initialFormData,
+    setFormData,
+    successMessage,
+}: Args) {
+    const useControlledClearEffect = <
+        K extends keyof FormData,
+        V extends ValueOf<FormData>["value"]
+    >(
+        controlField: V,
+        clearField: K,
+        controlCondition?: (value: V) => boolean
+    ) => {
+        const condition = controlCondition
+            ? controlCondition(controlField)
+            : controlField;
+        useEffect(() => {
+            if (!condition) {
+                setFormData((formData) => ({
+                    ...formData,
+                    [clearField]: initialFormData[clearField],
+                }));
+            }
+        }, [controlField]);
+    };
+
+    const useStrongholdDeselectEffect = (
+        deselectedStronghold: Stronghold,
+        controlCondition: boolean
+    ) => {
+        useEffect(() => {
+            if (!controlCondition) {
+                setFormData((formData) => ({
+                    ...formData,
+                    strongholds: {
+                        ...formData.strongholds,
+                        value: formData.strongholds.value.filter(
+                            (stronghold) => stronghold !== deselectedStronghold
+                        ),
+                    },
+                }));
+            }
+        }, [controlCondition]);
+    };
+
+    useEffect(
+        function resetForm() {
+            if (successMessage) setFormData(initialFormData);
+        },
+        [successMessage]
+    );
+
+    useControlledClearEffect(
+        formData.match.value,
+        "competition",
+        (match) => match === "Ranked"
+    );
+    useControlledClearEffect(
+        formData.match.value,
+        "league",
+        (match) => match === "Ranked"
+    );
+    useControlledClearEffect(
+        formData.competition.value,
+        "league",
+        (competition) => competition.includes("League")
+    );
+    useControlledClearEffect(
+        formData.expansions.value,
+        "treebeard",
+        (expansions) => expansions.includes("Treebeard")
+    );
+    useControlledClearEffect(formData.usedExpansions.value, "expansions");
+    useControlledClearEffect(formData.usedExpansions.value, "treebeard");
+    useControlledClearEffect(formData.usedHandicap.value, "actionTokens");
+    useControlledClearEffect(formData.usedHandicap.value, "dwarvenRings");
+    useControlledClearEffect(formData.didFellowshipReachMordor.value, "mordor");
+    useControlledClearEffect(formData.wasAragornCrowned.value, "aragornTurn");
+
+    strongholds.filter(isStrongholdConditional).map((stronghold) => {
+        useStrongholdDeselectEffect(
+            stronghold,
+            isStrongholdInPlay(formData.expansions.value, stronghold)
+        );
+    });
+}
+
+function isStrongholdConditional(stronghold: Stronghold): boolean {
+    return !isStrongholdInPlay([], stronghold);
+}

--- a/frontend/src/initialGameReportFormData.tsx
+++ b/frontend/src/initialGameReportFormData.tsx
@@ -1,4 +1,4 @@
-import { FormData } from "../../types";
+import { FormData } from "./types";
 
 const initialFormData: FormData = {
     winner: {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,4 +1,5 @@
 import {
+    availableYears,
     competitionTypes,
     expansions,
     leagues,
@@ -29,6 +30,8 @@ export type OptionalField = (typeof optionalFields)[number];
 
 export type PayloadField = (typeof payloadFields)[number];
 
+export type Year = (typeof availableYears)[number];
+
 export type SuccessMessage = string | null;
 
 export type ServerErrorBody = {
@@ -48,6 +51,10 @@ export interface FieldData<T> {
     error: FieldError;
     validate: () => FieldError;
 }
+
+export type ConstrainedFormData<F> = {
+    [K in keyof F]: F[K] extends FieldData<unknown> ? F[K] : never;
+};
 
 export interface FormData {
     winner: FieldData<string | null>;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,5 +1,4 @@
 import {
-    availableYears,
     competitionTypes,
     expansions,
     leagues,
@@ -29,8 +28,6 @@ export type Stronghold = (typeof strongholds)[number];
 export type OptionalField = (typeof optionalFields)[number];
 
 export type PayloadField = (typeof payloadFields)[number];
-
-export type Year = (typeof availableYears)[number];
 
 export type SuccessMessage = string | null;
 

--- a/frontend/src/utils.tsx
+++ b/frontend/src/utils.tsx
@@ -1,4 +1,4 @@
-import { Expansion, League, Side, Stronghold } from "./types";
+import { Expansion, League, ServerErrorBody, Side, Stronghold } from "./types";
 
 export function strongholdSide(
     expansions: Expansion[],
@@ -139,4 +139,59 @@ export function strongholdPoints(stronghold: Stronghold): 1 | 2 {
         case "Umbar":
             return 2;
     }
+}
+
+export function isStrongholdInPlay(
+    expansions: Expansion[],
+    stronghold: Stronghold
+): boolean {
+    switch (stronghold) {
+        case "EredLuin":
+            return expansions.includes("Cities");
+        case "SouthRhun":
+            return expansions.includes("Cities");
+        case "IronHills":
+            return expansions.includes("FateOfErebor");
+        case "Shire":
+        case "Edoras":
+        case "Dale":
+        case "Pelargir":
+        case "Rivendell":
+        case "GreyHavens":
+        case "HelmsDeep":
+        case "Lorien":
+        case "WoodlandRealm":
+        case "MinasTirith":
+        case "DolAmroth":
+        case "Erebor":
+        case "Angmar":
+        case "FarHarad":
+        case "MountGundabad":
+        case "Moria":
+        case "DolGuldur":
+        case "Orthanc":
+        case "Morannon":
+        case "BaradDur":
+        case "MinasMorgul":
+        case "Umbar":
+            return true;
+    }
+}
+
+export function isServerError(error: unknown): error is ServerErrorBody {
+    return (
+        typeof error === "object" &&
+        error !== null &&
+        "status" in error &&
+        typeof error.status === "number" &&
+        "response" in error &&
+        typeof error.response === "object" &&
+        error.response !== null &&
+        "data" in error.response &&
+        typeof error.response.data === "string"
+    );
+}
+
+export function objectKeys<T extends object>(obj: T): Array<keyof T> {
+    return Object.keys(obj) as Array<keyof T>;
 }

--- a/frontend/src/utils.tsx
+++ b/frontend/src/utils.tsx
@@ -195,3 +195,9 @@ export function isServerError(error: unknown): error is ServerErrorBody {
 export function objectKeys<T extends object>(obj: T): Array<keyof T> {
     return Object.keys(obj) as Array<keyof T>;
 }
+
+export function range(start: number = 0, end: number): number[] {
+    return end > start
+        ? [...Array(end - start).keys()].map((i) => i + start)
+        : [];
+}


### PR DESCRIPTION
This is a beast sorry, it's mostly just shifting code around! I managed to split this up from the player-edit buttons change, so hopefully that makes it easier to review. Edit buttons will be out in a sec, on top of this branch.

This changes `useFormData` to be usable by any of our forms so the state management can be consistent.

  - The hook was providing `GameReportForm` with a `/leaderboard` result in order to populate the `loser` and `winner` field autocompletion, so the `/leaderboard` request is now moved into `App`, which passes the result down to both `GameReportForm` and `Rankings` (which incidentally makes progress toward [#67](https://github.com/sirrus233/wotr-community-website/issues/67))

  - The `controlledClearEffect` and other game-form-specific effect code is now in a separate hook called `useGameReportFormEffects`

  - `initialFormData` is renamed to `initialGameReportFormData` and moved out of the `hooks` directory

  - The hook now accepts as arguments: `initialFormData`, a `submit` handler, an `optionalFields` list, and a `toErrorMessage` util. These are all dependent on which form is using the hook

  - `ConstrainedFormData` was the major interesting type that I had to work out to make this possible without losing any type safety