### PR TITLE
Frontend controls for editing and remapping of players

### DIFF
--- a/frontend/src/Autocomplete.tsx
+++ b/frontend/src/Autocomplete.tsx
@@ -59,11 +59,7 @@ export default function Autocomplete<O extends string | PlayerOption>({
                                 option.label === value)
                     );
 
-                    if (selected) {
-                        onChange(selected);
-                    } else {
-                        onChange(null);
-                    }
+                    onChange(selected || null);
                 }}
                 onChange={(_, value) => {
                     if (value) setDisplayedAlertText(null);

--- a/frontend/src/Autocomplete.tsx
+++ b/frontend/src/Autocomplete.tsx
@@ -3,26 +3,30 @@ import Alert from "@mui/joy/Alert";
 import Box from "@mui/joy/Box";
 import MaterialAutocomplete from "@mui/joy/Autocomplete";
 import CircularProgress from "@mui/joy/CircularProgress";
+import { PlayerOption } from "./types";
 
-interface Props {
-    options: string[]; // could update to allow objects: https://mui.com/joy-ui/react-autocomplete/
-    current: string;
+interface Props<O extends string | PlayerOption> {
+    options: O[];
+    current: O | null;
     placeholder: string;
     loading: boolean;
     alertText?: string;
-    onChange: (value: string) => void;
+    onChange?: (value: O | null) => void;
+    onInputValueChange?: (value: string) => void;
     validate: () => void;
 }
 
-export default function Autocomplete({
+export default function Autocomplete<O extends string | PlayerOption>({
     options,
     current,
     placeholder,
     loading,
     alertText,
-    onChange,
+    onChange = () => {},
+    onInputValueChange = () => {},
     validate,
-}: Props) {
+}: Props<O>) {
+    const [localInputValue, setLocalInputValue] = useState("");
     const [displayedAlertText, setDisplayedAlertText] =
         useState<ReactNode>(null);
 
@@ -39,9 +43,28 @@ export default function Autocomplete({
                 freeSolo
                 openOnFocus
                 options={options}
-                inputValue={current}
+                inputValue={
+                    typeof current === "string" ? current : localInputValue
+                }
+                value={current}
                 placeholder={placeholder}
-                onInputChange={(_, value) => onChange(value)}
+                onInputChange={(_, value) => {
+                    onInputValueChange(value);
+                    setLocalInputValue(value);
+
+                    const selected = options.find(
+                        (option) =>
+                            option === value ||
+                            (typeof option !== "string" &&
+                                option.label === value)
+                    );
+
+                    if (selected) {
+                        onChange(selected);
+                    } else {
+                        onChange(null);
+                    }
+                }}
                 onChange={(_, value) => {
                     if (value) setDisplayedAlertText(null);
                 }}

--- a/frontend/src/GameReportForm.tsx
+++ b/frontend/src/GameReportForm.tsx
@@ -135,7 +135,7 @@ function GameReportForm({ leaderboard, loadingLeaderboard }: Props) {
                             : ""
                     }
                     placeholder="Player Name - Please check spelling!"
-                    onChange={handleInputChange("winner")}
+                    onInputValueChange={handleInputChange("winner")}
                     validate={validateField("winner")}
                 />
             </GameReportFormElement>
@@ -154,7 +154,7 @@ function GameReportForm({ leaderboard, loadingLeaderboard }: Props) {
                             : ""
                     }
                     placeholder="Player Name - Please check spelling!"
-                    onChange={handleInputChange("loser")}
+                    onInputValueChange={handleInputChange("loser")}
                     validate={validateField("loser")}
                 />
             </GameReportFormElement>

--- a/frontend/src/GameReports.tsx
+++ b/frontend/src/GameReports.tsx
@@ -70,6 +70,16 @@ export default function GameReports() {
             containerStyle={{
                 maxHeight: `calc(100vh - ${TABLE_TOP_POSITION}px - ${TABLE_ELEMENTS_GAP}px)`,
             }}
+            tableStyle={{
+                "& thead > tr:first-child > *:first-child": {
+                    pl: 2,
+                },
+                "& tbody > tr > *:first-child": { pl: 2 },
+                "& thead > tr:first-child > *:last-child": {
+                    pr: 2,
+                },
+                "& tbody > tr > *:last-child": { pr: 2 },
+            }}
             header={
                 <tr>
                     <th />

--- a/frontend/src/PlayerEditForm.tsx
+++ b/frontend/src/PlayerEditForm.tsx
@@ -1,0 +1,146 @@
+import axios from "axios";
+import React, { useEffect } from "react";
+import Box from "@mui/joy/Box";
+import Button from "@mui/joy/Button";
+import CircularProgress from "@mui/joy/CircularProgress";
+import FormControl from "@mui/joy/FormControl";
+import FormHelperText from "@mui/joy/FormHelperText";
+import FormLabel from "@mui/joy/FormLabel";
+import Sheet from "@mui/joy/Sheet";
+import Typography from "@mui/joy/Typography";
+import {
+    PlayerEditFormData,
+    ServerErrorBody,
+    ValidPlayerEditFormData,
+} from "./types";
+import TextInput from "./TextInput";
+import useFormData from "./hooks/useFormData";
+
+interface Props {
+    pid: number;
+    name: string;
+    refresh: () => void;
+}
+
+export default function PlayerEditForm({ pid, name, refresh }: Props) {
+    const initialFormData: PlayerEditFormData = {
+        pid: {
+            value: pid,
+            error: null,
+            validate: () => null,
+        },
+        newName: {
+            value: null,
+            error: null,
+            validate: function _() {
+                return this.value?.toLowerCase().trim() ===
+                    name.toLowerCase().trim()
+                    ? "Cannot rename a player to the same name"
+                    : null;
+            },
+        },
+    };
+
+    const [
+        formData,
+        { errorOnSubmit, successMessage, loading },
+        { handleInputChange, validateField, handleSubmit, setSuccessMessage },
+    ] = useFormData<PlayerEditFormData, ValidPlayerEditFormData>({
+        initialFormData,
+        optionalFields: [],
+        submit,
+        toErrorMessage,
+    });
+
+    useEffect(
+        function refreshOnSubmit() {
+            if (successMessage) {
+                refresh();
+            }
+        },
+        [successMessage]
+    );
+
+    return (
+        <Sheet
+            sx={{
+                display: "flex",
+                flexDirection: "column",
+                alignItems: "center",
+                justifyContent: "center",
+            }}
+        >
+            {successMessage ? (
+                <Typography color="success">{successMessage}</Typography>
+            ) : (
+                <>
+                    <Typography level="title-lg">{name}</Typography>
+
+                    <Box sx={{ my: 2, width: "100%" }}>
+                        <FormControl error={!!formData.newName.error}>
+                            <FormLabel>New player name</FormLabel>
+
+                            <TextInput
+                                value={formData.newName.value || ""}
+                                placeholder="New player name"
+                                onChange={handleInputChange("newName")}
+                                validate={validateField("newName")}
+                            />
+
+                            {formData.newName.error && (
+                                <FormHelperText>
+                                    {formData.newName.error}
+                                </FormHelperText>
+                            )}
+                        </FormControl>
+                    </Box>
+
+                    <Button
+                        onClick={handleSubmit}
+                        disabled={loading}
+                        startDecorator={
+                            loading ? <CircularProgress /> : undefined
+                        }
+                    >
+                        {loading ? "Submitting..." : "Submit"}
+                    </Button>
+
+                    {errorOnSubmit && (
+                        <Typography color="danger" mt={1}>
+                            {errorOnSubmit}
+                        </Typography>
+                    )}
+                </>
+            )}
+        </Sheet>
+    );
+}
+
+async function submit(validFormData: ValidPlayerEditFormData) {
+    return await axios.post(
+        "https://api.waroftheringcommunity.net:8080/renamePlayer",
+        toPayload(validFormData),
+        {
+            headers: { "Content-Type": "application/json" },
+        }
+    );
+}
+
+type PlayerRenamePayload = {
+    pid: number;
+    newName: string;
+};
+
+function toPayload(formData: ValidPlayerEditFormData): PlayerRenamePayload {
+    return {
+        pid: formData.pid.value,
+        newName: formData.newName.value,
+    };
+}
+
+function toErrorMessage(error: ServerErrorBody): string {
+    if (error.status === 422) {
+        return error.response.data;
+    }
+    return "Something went wrong.";
+}

--- a/frontend/src/PlayerEditForm.tsx
+++ b/frontend/src/PlayerEditForm.tsx
@@ -44,7 +44,7 @@ export default function PlayerEditForm({ pid, name, refresh }: Props) {
     const [
         formData,
         { errorOnSubmit, successMessage, loading },
-        { handleInputChange, validateField, handleSubmit, setSuccessMessage },
+        { handleInputChange, validateField, handleSubmit },
     ] = useFormData<PlayerEditFormData, ValidPlayerEditFormData>({
         initialFormData,
         optionalFields: [],

--- a/frontend/src/PlayerRemapForm.tsx
+++ b/frontend/src/PlayerRemapForm.tsx
@@ -124,7 +124,7 @@ export default function PlayerRemapForm({
                                 handleSubmit();
                             } else {
                                 setWarningAlert(
-                                    `Danger: ${name} will cease to exist. ${formData.toPlayer.value?.label} will absorb all of ${name}'s history. ${name}'s history cannot be recovered. Continue?`
+                                    `Danger: ${name} will cease to exist. ${formData.toPlayer.value?.label} will absorb all of ${name}'s history. ${name}'s history cannot be recovered. If you're sure, press "Submit" again to continue.`
                                 );
                             }
                         }}

--- a/frontend/src/PlayerRemapForm.tsx
+++ b/frontend/src/PlayerRemapForm.tsx
@@ -1,0 +1,179 @@
+import axios from "axios";
+import React, { useEffect, useState } from "react";
+import Alert from "@mui/joy/Alert";
+import Box from "@mui/joy/Box";
+import Button from "@mui/joy/Button";
+import CircularProgress from "@mui/joy/CircularProgress";
+import FormControl from "@mui/joy/FormControl";
+import FormHelperText from "@mui/joy/FormHelperText";
+import FormLabel from "@mui/joy/FormLabel";
+import Sheet from "@mui/joy/Sheet";
+import Typography from "@mui/joy/Typography";
+import {
+    PlayerOption,
+    PlayerRemapFormData,
+    ServerErrorBody,
+    ValidPlayerRemapFormData,
+} from "./types";
+import Autocomplete from "./Autocomplete";
+import useFormData from "./hooks/useFormData";
+import { ErrorMessage } from "./constants";
+
+interface Props {
+    pid: number;
+    name: string;
+    playerOptions: PlayerOption[];
+    refresh: () => void;
+}
+
+export default function PlayerRemapForm({
+    pid,
+    name,
+    playerOptions,
+    refresh,
+}: Props) {
+    const initialFormData: PlayerRemapFormData = {
+        fromPlayer: {
+            value: { pid, label: name },
+            error: null,
+            validate: () => null,
+        },
+        toPlayer: {
+            value: null,
+            error: null,
+            validate: function _() {
+                return this.value
+                    ? pid === this.value.pid
+                        ? "Cannot remap player to themselves"
+                        : null
+                    : null;
+            },
+        },
+    };
+
+    const [
+        formData,
+        { errorOnSubmit, successMessage, loading },
+        { handleInputChange, validateField, handleSubmit },
+    ] = useFormData<PlayerRemapFormData, ValidPlayerRemapFormData>({
+        initialFormData,
+        optionalFields: [],
+        missingFieldErrorMessage: ErrorMessage.ExistingPlayerRequired,
+        submit,
+        toErrorMessage,
+    });
+
+    const [warningAlert, setWarningAlert] = useState<string | null>(null);
+
+    useEffect(
+        function refreshOnSubmit() {
+            if (successMessage) {
+                refresh();
+            }
+        },
+        [successMessage]
+    );
+
+    return (
+        <Sheet
+            sx={{
+                display: "flex",
+                flexDirection: "column",
+                alignItems: "center",
+                justifyContent: "center",
+            }}
+        >
+            {successMessage ? (
+                <Typography color="success">{successMessage}</Typography>
+            ) : (
+                <>
+                    <Typography level="title-lg">{name}</Typography>
+
+                    <Box sx={{ my: 2, width: "100%" }}>
+                        <FormControl error={!!formData.toPlayer.error}>
+                            <FormLabel>
+                                Reassign this player's games to:
+                            </FormLabel>
+
+                            <Autocomplete
+                                current={formData.toPlayer.value}
+                                options={playerOptions}
+                                placeholder="Player name"
+                                loading={false}
+                                onChange={handleInputChange("toPlayer")}
+                                validate={validateField("toPlayer")}
+                            />
+
+                            {formData.toPlayer.error && (
+                                <FormHelperText>
+                                    {formData.toPlayer.error}
+                                </FormHelperText>
+                            )}
+                        </FormControl>
+
+                        {warningAlert && (
+                            <Alert color="warning" sx={{ my: "10px" }}>
+                                {warningAlert}
+                            </Alert>
+                        )}
+                    </Box>
+
+                    <Button
+                        onClick={() => {
+                            if (warningAlert || formData.toPlayer.error) {
+                                handleSubmit();
+                            } else {
+                                setWarningAlert(
+                                    `Danger: ${name} will cease to exist. ${formData.toPlayer.value?.label} will absorb all of ${name}'s history. ${name}'s history cannot be recovered. Continue?`
+                                );
+                            }
+                        }}
+                        disabled={loading}
+                        startDecorator={
+                            loading ? <CircularProgress /> : undefined
+                        }
+                    >
+                        {loading ? "Submitting..." : "Submit"}
+                    </Button>
+
+                    {errorOnSubmit && (
+                        <Typography color="danger" mt={1}>
+                            {errorOnSubmit}
+                        </Typography>
+                    )}
+                </>
+            )}
+        </Sheet>
+    );
+}
+
+async function submit(validFormData: ValidPlayerRemapFormData) {
+    return await axios.post(
+        "https://api.waroftheringcommunity.net:8080/remapPlayer",
+        toPayload(validFormData),
+        {
+            headers: { "Content-Type": "application/json" },
+        }
+    );
+}
+
+type PlayerRemapPayload = {
+    fromPid: number;
+    toPid: number;
+};
+
+function toPayload(
+    validFormData: ValidPlayerRemapFormData
+): PlayerRemapPayload {
+    return {
+        fromPid: validFormData.fromPlayer.value.pid,
+        toPid: validFormData.toPlayer.value.pid,
+    };
+}
+
+function toErrorMessage(error: ServerErrorBody): string {
+    if (error.status === 422) {
+        return error.response.data;
+    }
+    return "Something went wrong.";
+}

--- a/frontend/src/Rankings.tsx
+++ b/frontend/src/Rankings.tsx
@@ -2,7 +2,13 @@ import React, { CSSProperties, ReactNode, useState } from "react";
 import Box from "@mui/joy/Box";
 import Button from "@mui/joy/Button";
 import ButtonGroup from "@mui/joy/ButtonGroup";
-import { LeaderboardEntry, Side } from "./types";
+import EditIcon from "@mui/icons-material/EditOutlined";
+import IconButton from "@mui/joy/IconButton";
+import MergeIcon from "@mui/icons-material/Merge";
+import Modal from "@mui/joy/Modal";
+import ModalClose from "@mui/joy/ModalClose";
+import ModalDialog from "@mui/joy/ModalDialog";
+import { LeaderboardEntry, PlayerEditMode, Side } from "./types";
 import { FREE_PRIMARY_COLOR, SHADOW_PRIMARY_COLOR } from "./styles/colors";
 import {
     HEADER_HEIGHT_PX,
@@ -10,9 +16,17 @@ import {
     TABLE_REFRESH_BTN_HEIGHT_PX,
     TABLE_ELEMENTS_GAP,
 } from "./styles/sizes";
+import PlayerEditForm from "./PlayerEditForm";
+import PlayerRemapForm from "./PlayerRemapForm";
 import TableView from "./TableView";
 import { range } from "./utils";
 import { START_YEAR } from "./constants";
+
+type PlayerEditParams = {
+    pid: number;
+    name: string;
+    mode: PlayerEditMode;
+};
 
 interface Props {
     leaderboard: LeaderboardEntry[];
@@ -41,6 +55,9 @@ function Rankings({
 }: Props) {
     const [error, setError] = useState<string | null>(null);
 
+    const [playerEditParams, setPlayerEditParams] =
+        useState<PlayerEditParams | null>(null);
+
     const refresh = () => {
         setError(null);
         getLeaderboard();
@@ -50,6 +67,29 @@ function Rankings({
 
     return (
         <Box>
+            {playerEditParams && (
+                <Modal open onClose={() => setPlayerEditParams(null)}>
+                    <ModalDialog>
+                        <ModalClose />
+                        {playerEditParams.mode === "remap" ? (
+                            <PlayerRemapForm
+                                {...playerEditParams}
+                                refresh={refresh}
+                                playerOptions={leaderboard.map((entry) => ({
+                                    label: entry.name,
+                                    pid: entry.pid,
+                                }))}
+                            />
+                        ) : (
+                            <PlayerEditForm
+                                {...playerEditParams}
+                                refresh={refresh}
+                            />
+                        )}
+                    </ModalDialog>
+                </Modal>
+            )}
+
             <Box
                 sx={{
                     display: "flex",
@@ -85,6 +125,9 @@ function Rankings({
                 header={
                     <>
                         <TableHeaderRow>
+                            <TableHeaderCell level={0} rowSpan={3}>
+                                Edit Player
+                            </TableHeaderCell>
                             <TableHeaderCell level={0} rowSpan={3}>
                                 Rank
                             </TableHeaderCell>
@@ -162,6 +205,36 @@ function Rankings({
                 }
                 body={leaderboard.map((entry, i) => (
                     <tr key={entry.pid}>
+                        <TableCell>
+                            <IconButton
+                                size="sm"
+                                disabled={loading}
+                                onClick={() =>
+                                    setPlayerEditParams({
+                                        pid: entry.pid,
+                                        name: entry.name,
+                                        mode: "edit",
+                                    })
+                                }
+                            >
+                                <EditIcon />
+                            </IconButton>
+
+                            <IconButton
+                                size="sm"
+                                disabled={loading}
+                                onClick={() =>
+                                    setPlayerEditParams({
+                                        pid: entry.pid,
+                                        name: entry.name,
+                                        mode: "remap",
+                                    })
+                                }
+                            >
+                                <MergeIcon />
+                            </IconButton>
+                        </TableCell>
+
                         <TableCell>{i + 1}</TableCell>
                         <TableCell>{entry.country}</TableCell>
                         <TableCell>{entry.name}</TableCell>

--- a/frontend/src/TableView.tsx
+++ b/frontend/src/TableView.tsx
@@ -3,6 +3,7 @@ import Box from "@mui/joy/Box";
 import Button from "@mui/joy/Button";
 import Table from "@mui/joy/Table";
 import Typography from "@mui/joy/Typography";
+import { SxProps } from "@mui/joy/styles/types";
 import {
     TABLE_REFRESH_BTN_HEIGHT_PX,
     TABLE_ELEMENTS_GAP,
@@ -16,6 +17,7 @@ interface Props {
     header: ReactNode;
     body: ReactNode;
     containerStyle?: CSSProperties;
+    tableStyle?: SxProps;
 }
 
 export default function TableView({
@@ -26,6 +28,7 @@ export default function TableView({
     header,
     body,
     containerStyle = {},
+    tableStyle = {},
 }: Props) {
     return (
         <Box
@@ -76,14 +79,7 @@ export default function TableView({
                             tableLayout: "auto",
                             border: "none",
                             "& tr > *": { textAlign: "center" },
-                            "& thead > tr:first-child > *:first-child": {
-                                pl: 2,
-                            },
-                            "& tbody > tr > *:first-child": { pl: 2 },
-                            "& thead > tr:first-child > *:last-child": {
-                                pr: 2,
-                            },
-                            "& tbody > tr > *:last-child": { pr: 2 },
+                            ...tableStyle,
                         }}
                     >
                         <thead>{header}</thead>

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -103,6 +103,7 @@ export enum ErrorMessage {
     Required = "Required",
     OnSubmit = "Could not submit, please resolve errors",
     MissingPlayerName = "This player does not exist in the database. Unless it's a new player, please check the spelling.",
+    ExistingPlayerRequired = "Must choose an existing player",
 }
 
 export const INFINITE = 100;

--- a/frontend/src/hooks/useFormData/index.tsx
+++ b/frontend/src/hooks/useFormData/index.tsx
@@ -28,7 +28,7 @@ interface Args<F, V> {
     initialFormData: ConstrainedFormData<F>;
     optionalFields: string[];
     missingFieldErrorMessage?: ErrorMessage;
-    submit: (validatedFormData: ConstrainedFormData<V>) => Promise<any>; // FIXME
+    submit: (validatedFormData: ConstrainedFormData<V>) => Promise<any>;
     toErrorMessage: (error: ServerErrorBody) => string;
 }
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -142,4 +142,39 @@ export interface ProcessedGameReport {
     comments: string | null;
 }
 
+export type PlayerEditMode = "edit" | "remap";
+
+export type PlayerOption = {
+    label: string;
+    pid: number;
+};
+
+export interface PlayerEditFormData {
+    pid: FieldData<number>;
+    newName: FieldData<string | null>;
+}
+
+export type ValidPlayerEditFormData = {
+    [K in keyof PlayerEditFormData]: {
+        [J in keyof PlayerEditFormData[K]]: Exclude<
+            PlayerEditFormData[K][J],
+            null
+        >;
+    };
+};
+
+export interface PlayerRemapFormData {
+    fromPlayer: FieldData<PlayerOption>;
+    toPlayer: FieldData<PlayerOption | null>;
+}
+
+export type ValidPlayerRemapFormData = {
+    [K in keyof PlayerRemapFormData]: {
+        [J in keyof PlayerRemapFormData[K]]: Exclude<
+            PlayerRemapFormData[K][J],
+            null
+        >;
+    };
+};
+
 export type ValueOf<T> = T[keyof T];


### PR DESCRIPTION
- On leaderboard page, adds an edit pencil/`PlayerEditForm` and merge icon/`PlayerRemapForm`, for editing a player's info and remapping a player, respectively

- Expands the `Autocomplete` to allow more complex options (I went with `(string | PlayerOption)[]` for right now, but really it should be more generic, like `(string | Option)[]` and then map `playerOptions` to the generic interface. That can always be improved upon when we need an autocomplete somewhere else, I just got tired

- For the `PlayerRemapForm`, when you click submit, it's a fake-out the first time, and a "danger" alert gets displayed. The alert tells you to click submit again if you're sure

- The input in both forms get the standard "Required" validation, and one layer on top of that, which disallows the input to match the edited player's name