### PR TITLE
Add filter buttons for player active status to leaderboard

### DIFF
--- a/frontend/src/Filters.tsx
+++ b/frontend/src/Filters.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import Checkbox from "@mui/joy/Checkbox";
+import List from "@mui/joy/List";
+import ListItem from "@mui/joy/ListItem";
+
+interface Props<T> {
+    options: T[];
+    current: T[];
+    onChange: (value: T[]) => void;
+}
+
+export default function Filters<T>({ options, current, onChange }: Props<T>) {
+    const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+        const selectedValue = options.find(
+            (value) => String(value) === event.target.value
+        );
+        if (selectedValue !== undefined) {
+            if (event.target.checked) {
+                onChange(current.concat(selectedValue));
+            } else {
+                onChange(current.filter((value) => value !== selectedValue));
+            }
+        }
+    };
+
+    return (
+        <List
+            orientation="horizontal"
+            wrap
+            sx={{
+                display: "flex",
+                flexDirection: "row",
+                alignItems: "center",
+                justifyContent: "center",
+                "--List-gap": "10px",
+                "--ListItem-radius": "30px",
+                "--ListItem-minHeight": "32px",
+            }}
+        >
+            {options.map((option, i) => (
+                <ListItem key={i}>
+                    <Checkbox
+                        checked={current.includes(option)}
+                        size="sm"
+                        disableIcon
+                        overlay
+                        value={String(option)}
+                        label={String(option)}
+                        onChange={handleChange}
+                    />
+                </ListItem>
+            ))}
+        </List>
+    );
+}

--- a/frontend/src/GameReports.tsx
+++ b/frontend/src/GameReports.tsx
@@ -16,7 +16,7 @@ import { FREE_ACCENT_COLOR, SHADOW_PRIMARY_COLOR } from "./styles/colors";
 import {
     HEADER_HEIGHT_PX,
     HEADER_MARGIN_PX,
-    TABLE_REFRESH_BTN_HEIGHT_PX,
+    TABLE_BTN_HEIGHT_PX,
     TABLE_ELEMENTS_GAP,
 } from "./styles/sizes";
 import {
@@ -31,7 +31,7 @@ import TableView from "./TableView";
 const TABLE_TOP_POSITION =
     HEADER_HEIGHT_PX +
     HEADER_MARGIN_PX +
-    TABLE_REFRESH_BTN_HEIGHT_PX +
+    TABLE_BTN_HEIGHT_PX +
     TABLE_ELEMENTS_GAP * 2;
 
 export default function GameReports() {

--- a/frontend/src/Rankings.tsx
+++ b/frontend/src/Rankings.tsx
@@ -8,19 +8,20 @@ import MergeIcon from "@mui/icons-material/Merge";
 import Modal from "@mui/joy/Modal";
 import ModalClose from "@mui/joy/ModalClose";
 import ModalDialog from "@mui/joy/ModalDialog";
-import { LeaderboardEntry, PlayerEditMode, Side } from "./types";
+import { LeaderboardEntry, PlayerEditMode, PlayerState, Side } from "./types";
 import { FREE_PRIMARY_COLOR, SHADOW_PRIMARY_COLOR } from "./styles/colors";
 import {
     HEADER_HEIGHT_PX,
     HEADER_MARGIN_PX,
-    TABLE_REFRESH_BTN_HEIGHT_PX,
+    TABLE_BTN_HEIGHT_PX,
     TABLE_ELEMENTS_GAP,
 } from "./styles/sizes";
+import Filters from "./Filters";
 import PlayerEditForm from "./PlayerEditForm";
 import PlayerRemapForm from "./PlayerRemapForm";
 import TableView from "./TableView";
 import { range } from "./utils";
-import { START_YEAR } from "./constants";
+import { playerStates, START_YEAR } from "./constants";
 
 type PlayerEditParams = {
     pid: number;
@@ -43,8 +44,8 @@ const TABLE_TOP_POSITION =
     HEADER_HEIGHT_PX +
     HEADER_MARGIN_PX +
     YEAR_SELECTOR_HEIGHT +
-    TABLE_REFRESH_BTN_HEIGHT_PX +
-    TABLE_ELEMENTS_GAP * 2;
+    TABLE_BTN_HEIGHT_PX * 2 +
+    TABLE_ELEMENTS_GAP * 3;
 
 function Rankings({
     leaderboard,
@@ -53,6 +54,7 @@ function Rankings({
     getLeaderboard,
     setYear,
 }: Props) {
+    const [filters, setFilters] = useState<PlayerState[]>(["Active"]);
     const [error, setError] = useState<string | null>(null);
 
     const [playerEditParams, setPlayerEditParams] =
@@ -119,6 +121,13 @@ function Rankings({
                 error={error}
                 loading={loading}
                 label="Rankings"
+                filters={
+                    <Filters
+                        options={playerStates.slice()}
+                        current={filters}
+                        onChange={setFilters}
+                    />
+                }
                 containerStyle={{
                     maxHeight: `calc(100vh - ${TABLE_TOP_POSITION}px - ${TABLE_ELEMENTS_GAP}px)`,
                 }}
@@ -203,70 +212,76 @@ function Rankings({
                         </TableHeaderRow>
                     </>
                 }
-                body={leaderboard.map((entry, i) => (
-                    <tr key={entry.pid}>
-                        <TableCell>
-                            <IconButton
-                                size="sm"
-                                disabled={loading}
-                                onClick={() =>
-                                    setPlayerEditParams({
-                                        pid: entry.pid,
-                                        name: entry.name,
-                                        mode: "edit",
-                                    })
-                                }
-                            >
-                                <EditIcon />
-                            </IconButton>
+                body={leaderboard
+                    .filter(
+                        (entry) =>
+                            (entry.isActive && filters.includes("Active")) ||
+                            (!entry.isActive && filters.includes("Inactive"))
+                    )
+                    .map((entry, i) => (
+                        <tr key={entry.pid}>
+                            <TableCell>
+                                <IconButton
+                                    size="sm"
+                                    disabled={loading}
+                                    onClick={() =>
+                                        setPlayerEditParams({
+                                            pid: entry.pid,
+                                            name: entry.name,
+                                            mode: "edit",
+                                        })
+                                    }
+                                >
+                                    <EditIcon />
+                                </IconButton>
 
-                            <IconButton
-                                size="sm"
-                                disabled={loading}
-                                onClick={() =>
-                                    setPlayerEditParams({
-                                        pid: entry.pid,
-                                        name: entry.name,
-                                        mode: "remap",
-                                    })
-                                }
-                            >
-                                <MergeIcon />
-                            </IconButton>
-                        </TableCell>
+                                <IconButton
+                                    size="sm"
+                                    disabled={loading}
+                                    onClick={() =>
+                                        setPlayerEditParams({
+                                            pid: entry.pid,
+                                            name: entry.name,
+                                            mode: "remap",
+                                        })
+                                    }
+                                >
+                                    <MergeIcon />
+                                </IconButton>
+                            </TableCell>
 
-                        <TableCell>{i + 1}</TableCell>
-                        <TableCell>{entry.country}</TableCell>
-                        <TableCell>{entry.name}</TableCell>
-                        <TableCell>{entry.averageRating}</TableCell>
-                        <TableCell side="Shadow">
-                            {entry.currentRatingShadow}
-                        </TableCell>
-                        <TableCell side="Free">
-                            {entry.currentRatingFree}
-                        </TableCell>
-                        <TableCell>{entry.totalGames}</TableCell>
-                        <TableCell>{entry.yearlyGames}</TableCell>
-                        <TableCell side="Free" light>
-                            {entry.yearlyWinsFree}
-                        </TableCell>
-                        <TableCell side="Free">
-                            {entry.yearlyLossesFree}
-                        </TableCell>
-                        <TableCell>
-                            {toPercent(entry.yearlyWinRateFree)}
-                        </TableCell>
-                        <TableCell side="Shadow" light>
-                            {entry.yearlyWinsShadow}
-                        </TableCell>
-                        <TableCell side="Shadow">
-                            {entry.yearlyLossesShadow}
-                        </TableCell>
-                        <TableCell>
-                            {toPercent(entry.yearlyWinRateShadow)}
-                        </TableCell>
-                    </tr>
-                ))}
+                            <TableCell>{i + 1}</TableCell>
+                            <TableCell>{entry.country}</TableCell>
+                            <TableCell>{entry.name}</TableCell>
+                            <TableCell>{entry.averageRating}</TableCell>
+                            <TableCell side="Shadow">
+                                {entry.currentRatingShadow}
+                            </TableCell>
+                            <TableCell side="Free">
+                                {entry.currentRatingFree}
+                            </TableCell>
+                            <TableCell>{entry.totalGames}</TableCell>
+                            <TableCell>{entry.yearlyGames}</TableCell>
+                            <TableCell side="Free" light>
+                                {entry.yearlyWinsFree}
+                            </TableCell>
+                            <TableCell side="Free">
+                                {entry.yearlyLossesFree}
+                            </TableCell>
+                            <TableCell>
+                                {toPercent(entry.yearlyWinRateFree)}
+                            </TableCell>
+                            <TableCell side="Shadow" light>
+                                {entry.yearlyWinsShadow}
+                            </TableCell>
+                            <TableCell side="Shadow">
+                                {entry.yearlyLossesShadow}
+                            </TableCell>
+                            <TableCell>
+                                {toPercent(entry.yearlyWinRateShadow)}
+                            </TableCell>
+                        </tr>
+                    ))}
             />
         </Box>
     );

--- a/frontend/src/TableView.tsx
+++ b/frontend/src/TableView.tsx
@@ -4,10 +4,7 @@ import Button from "@mui/joy/Button";
 import Table from "@mui/joy/Table";
 import Typography from "@mui/joy/Typography";
 import { SxProps } from "@mui/joy/styles/types";
-import {
-    TABLE_REFRESH_BTN_HEIGHT_PX,
-    TABLE_ELEMENTS_GAP,
-} from "./styles/sizes";
+import { TABLE_BTN_HEIGHT_PX, TABLE_ELEMENTS_GAP } from "./styles/sizes";
 
 interface Props {
     refresh: () => void;
@@ -16,6 +13,7 @@ interface Props {
     label: string;
     header: ReactNode;
     body: ReactNode;
+    filters?: ReactNode;
     containerStyle?: CSSProperties;
     tableStyle?: SxProps;
 }
@@ -25,6 +23,7 @@ export default function TableView({
     error,
     loading,
     label,
+    filters,
     header,
     body,
     containerStyle = {},
@@ -45,16 +44,31 @@ export default function TableView({
                     width: "100%",
                     alignItems: "center",
                     justifyContent: "center",
-                    margin: `${TABLE_ELEMENTS_GAP}px 0`,
+                    m: `${TABLE_ELEMENTS_GAP}px 0`,
                 }}
             >
                 <Button
                     onClick={refresh}
-                    sx={{ height: `${TABLE_REFRESH_BTN_HEIGHT_PX}px` }}
+                    sx={{ height: `${TABLE_BTN_HEIGHT_PX}px` }}
                 >
                     Refresh
                 </Button>
             </Box>
+
+            {filters && (
+                <Box
+                    sx={{
+                        display: "flex",
+                        width: "100%",
+                        alignItems: "center",
+                        justifyContent: "center",
+                        height: `${TABLE_BTN_HEIGHT_PX}px`,
+                        mb: `${TABLE_ELEMENTS_GAP}px`,
+                    }}
+                >
+                    {filters}
+                </Box>
+            )}
 
             {error && <Typography color="danger">{error}</Typography>}
 

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -99,6 +99,8 @@ export const serverValidationErrors = [
     "InvalidStronghold",
 ] as const;
 
+export const playerStates = ["Active", "Inactive"] as const;
+
 export enum ErrorMessage {
     Required = "Required",
     OnSubmit = "Could not submit, please resolve errors",

--- a/frontend/src/styles/sizes.ts
+++ b/frontend/src/styles/sizes.ts
@@ -1,4 +1,4 @@
 export const HEADER_HEIGHT_PX = 44;
 export const HEADER_MARGIN_PX = 20;
-export const TABLE_REFRESH_BTN_HEIGHT_PX = 36;
+export const TABLE_BTN_HEIGHT_PX = 36;
 export const TABLE_ELEMENTS_GAP = 16;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -5,6 +5,7 @@ import {
     matchTypes,
     optionalFields,
     payloadFields,
+    playerStates,
     serverValidationErrors,
     sides,
     strongholds,
@@ -28,6 +29,8 @@ export type Stronghold = (typeof strongholds)[number];
 export type OptionalField = (typeof optionalFields)[number];
 
 export type PayloadField = (typeof payloadFields)[number];
+
+export type PlayerState = (typeof playerStates)[number];
 
 export type SuccessMessage = string | null;
 
@@ -96,6 +99,7 @@ export interface LeaderboardEntry {
     pid: number;
     name: string;
     country: string | null;
+    isActive: boolean;
     currentRatingFree: number;
     currentRatingShadow: number;
     averageRating: number;


### PR DESCRIPTION
Adds buttons above leaderboard table for filtering on active/inactive player status. Your API works great!

Includes a `Filters` component (a ripoff of `MultiOptionInput` for the most part) that we can reuse for more table filtering in the future.

Toggling between the filters is unbearably slow, MUI tables rendering performance strikes again 😬 