### PR TITLE
Support submission of game logs

### DIFF
--- a/backend/.vscode/settings.json
+++ b/backend/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
     "cSpell.words": [
         "Aeson",
+        "Amazonka",
         "Amroth",
         "Angmar",
         "aragorn",

--- a/backend/app/Migration.hs
+++ b/backend/app/Migration.hs
@@ -14,7 +14,7 @@ import Logging (Logger, log, stdoutLogger, (<>:))
 import Servant (ServerError (errBody), err500, runHandler, throwError)
 import System.Directory (createDirectoryIfMissing)
 import System.FilePath (takeDirectory)
-import Types.Api (RawGameReport (..))
+import Types.Api (RawGameReport (victory))
 import Types.DataField (Victory (..))
 import Types.Database (migrateAll)
 import Types.Migration

--- a/backend/app/Migration.hs
+++ b/backend/app/Migration.hs
@@ -37,9 +37,9 @@ migrate legacyEntries reports = runDb $ do
   forM_ (map (\r -> (r.timestamp, toRawGameReport r)) reports) $ \(timestamp, report) -> do
     case validateReport report of
       Failure errs -> case errs of
-        [NoVictoryConditionMet] -> insertReport_ timestamp (report {victory = Concession})
+        [NoVictoryConditionMet] -> insertReport_ timestamp (report {victory = Concession}) Nothing
         _ -> throwError $ err500 {errBody = "Unrecognized failure: " <>: errs <> " for report: " <>: report}
-      Success _ -> insertReport_ timestamp report
+      Success _ -> insertReport_ timestamp report Nothing
 
   reprocessReports
 

--- a/backend/cabal.project
+++ b/backend/cabal.project
@@ -1,0 +1,22 @@
+packages: .
+
+allow-newer: amazonka:base
+package amazonka
+  ghc-options: -XDuplicateRecordFields
+
+allow-newer: amazonka-core:base
+package amazonka-core
+  ghc-options: -XDuplicateRecordFields
+
+allow-newer: amazonka-s3:base
+package amazonka-s3
+  ghc-options: -XDuplicateRecordFields
+
+allow-newer: amazonka-sts:base
+package amazonka-sts
+  ghc-options: -XDuplicateRecordFields
+
+allow-newer: amazonka-sso:base
+package amazonka-sso
+  ghc-options: -XDuplicateRecordFields
+

--- a/backend/src/Api.hs
+++ b/backend/src/Api.hs
@@ -1,19 +1,20 @@
 module Api where
 
 import Servant (Get, JSON, Post, PostNoContent, QueryParam', ReqBody, Required, (:<|>), (:>))
+import Servant.Multipart (MultipartForm, Tmp)
 import Types.Api
   ( DeleteReportRequest,
     GetLeaderboardResponse,
     GetReportsResponse,
     ModifyReportRequest,
-    RawGameReport,
     RemapPlayerRequest,
     RemapPlayerResponse,
     RenamePlayerRequest,
     SubmitGameReportResponse,
+    SubmitReportRequest,
   )
 
-type SubmitReportAPI = "submitReport" :> ReqBody '[JSON] RawGameReport :> Post '[JSON] SubmitGameReportResponse
+type SubmitReportAPI = "submitReport" :> MultipartForm Tmp SubmitReportRequest :> Post '[JSON] SubmitGameReportResponse
 
 type GetReportsAPI = "reports" :> Get '[JSON] GetReportsResponse
 

--- a/backend/src/AppConfig.hs
+++ b/backend/src/AppConfig.hs
@@ -1,5 +1,6 @@
 module AppConfig where
 
+import Amazonka qualified as AWS
 import Amazonka.S3 qualified as S3
 import Control.Monad.Logger (LoggingT (runLoggingT), filterLogger)
 import Database.Esqueleto.Experimental qualified as SQL
@@ -8,7 +9,7 @@ import Database.Redis qualified as Redis
 import Logging (LogLevelFilter, Logger, filterInfo)
 import Servant (Handler)
 
-data Env = Env {dbPool :: SQL.ConnectionPool, redisPool :: Redis.Connection, logger :: Logger}
+data Env = Env {dbPool :: SQL.ConnectionPool, redisPool :: Redis.Connection, logger :: Logger, aws :: AWS.Env}
 
 type AppM = ReaderT Env (LoggingT Handler)
 

--- a/backend/src/AppConfig.hs
+++ b/backend/src/AppConfig.hs
@@ -1,5 +1,6 @@
 module AppConfig where
 
+import Amazonka.S3 qualified as S3
 import Control.Monad.Logger (LoggingT (runLoggingT), filterLogger)
 import Database.Esqueleto.Experimental qualified as SQL
 import Database.Redis (ConnectInfo, defaultConnectInfo)
@@ -16,6 +17,9 @@ databaseFile = "data/db.sqlite"
 
 logFile :: FilePath
 logFile = "logs/app.log"
+
+gameLogBucket :: S3.BucketName
+gameLogBucket = "infrastructurestack-gamereportbucket21a257d2-v7okzv3x39a9"
 
 redisConfig :: ConnectInfo
 redisConfig = defaultConnectInfo

--- a/backend/src/AppServer.hs
+++ b/backend/src/AppServer.hs
@@ -122,14 +122,16 @@ readOrError errMsg action =
 
 toS3Key :: UTCTime -> PlayerName -> PlayerName -> S3.ObjectKey
 toS3Key timestamp freePlayer shadowPlayer =
-  S3.ObjectKey $ show y <> "/" <>: m <> "/" <>: d <> "/" <> ts <> "_FP_" <> freePlayer <> "_SP_" <> shadowPlayer <> ".log"
+  S3.ObjectKey $ formattedPath <> formattedFilename
   where
     (y, m, d) = toGregorian . utctDay $ timestamp
-    ts = toText . formatTime defaultTimeLocale "%Y-%m-%d_%H%M%S" $ timestamp
+    formattedPath = show y <> "/" <>: m <> "/" <>: d <> "/"
+    formattedTimestamp = toText . formatTime defaultTimeLocale "%Y-%m-%d_%H%M%S" $ timestamp
+    formattedFilename = formattedTimestamp <> "_FP_" <> freePlayer <> "_SP_" <> shadowPlayer <> ".log"
 
-toS3Url :: S3.ObjectKey -> S3Url
-toS3Url (S3.ObjectKey key) =
-  "https://" <> S3.fromBucketName gameLogBucket <> ".s3." <> AWS.fromRegion AWS.Oregon <> ".amazonaws.com/" <> key
+toS3Url :: AWS.Env -> S3.ObjectKey -> S3Url
+toS3Url (AWS.Env {AWS.region}) (S3.ObjectKey key) =
+  "https://" <> S3.fromBucketName gameLogBucket <> ".s3." <> AWS.fromRegion region <> ".amazonaws.com/" <> key
 
 putS3Object :: (MonadIO m) => FilePath -> S3.ObjectKey -> m S3.PutObjectResponse
 putS3Object path key = do

--- a/backend/src/AppServer.hs
+++ b/backend/src/AppServer.hs
@@ -39,6 +39,7 @@ import Types.Api
     RemapPlayerRequest (..),
     RemapPlayerResponse (..),
     RenamePlayerRequest (..),
+    S3Path,
     SubmitGameReportResponse (..),
     SubmitReportRequest (..),
     fromGameReport,
@@ -117,14 +118,14 @@ readOrError errMsg action =
       logErrorN errMsg
       throwError err404 {errBody = show errMsg}
 
-insertReport :: (MonadIO m, MonadLogger m) => UTCTime -> RawGameReport -> Maybe Text -> DBAction m ReportInsertion
+insertReport :: (MonadIO m, MonadLogger m) => UTCTime -> RawGameReport -> Maybe S3Path -> DBAction m ReportInsertion
 insertReport timestamp rawReport logFilePath = do
   winner <- insertPlayerIfNotExists rawReport.winner
   loser <- insertPlayerIfNotExists rawReport.loser
   report <- insertGameReport $ toGameReport timestamp (entityKey winner) (entityKey loser) logFilePath rawReport
   pure (report, winner, loser)
 
-insertReport_ :: (MonadIO m, MonadLogger m) => UTCTime -> RawGameReport -> Maybe Text -> DBAction m ()
+insertReport_ :: (MonadIO m, MonadLogger m) => UTCTime -> RawGameReport -> Maybe S3Path -> DBAction m ()
 insertReport_ timestamp rawReport logFilePath = insertReport timestamp rawReport logFilePath >> pass
 
 processReport :: (MonadIO m, MonadLogger m) => ReportInsertion -> DBAction m (ProcessedGameReport, Rating, Rating)

--- a/backend/src/AppServer.hs
+++ b/backend/src/AppServer.hs
@@ -142,14 +142,14 @@ putS3Object_ :: (MonadIO m) => FilePath -> S3.ObjectKey -> m ()
 putS3Object_ path key = putS3Object path key >> pass
 
 insertReport :: (MonadIO m, MonadLogger m) => UTCTime -> RawGameReport -> Maybe S3Url -> DBAction m ReportInsertion
-insertReport timestamp rawReport logFilePath = do
+insertReport timestamp rawReport s3Url = do
   winner <- insertPlayerIfNotExists rawReport.winner
   loser <- insertPlayerIfNotExists rawReport.loser
-  report <- insertGameReport $ toGameReport timestamp (entityKey winner) (entityKey loser) logFilePath rawReport
+  report <- insertGameReport $ toGameReport timestamp (entityKey winner) (entityKey loser) s3Url rawReport
   pure (report, winner, loser)
 
 insertReport_ :: (MonadIO m, MonadLogger m) => UTCTime -> RawGameReport -> Maybe S3Url -> DBAction m ()
-insertReport_ timestamp rawReport logFilePath = insertReport timestamp rawReport logFilePath >> pass
+insertReport_ timestamp rawReport s3Url = insertReport timestamp rawReport s3Url >> pass
 
 processReport :: (MonadIO m, MonadLogger m) => ReportInsertion -> DBAction m (ProcessedGameReport, Rating, Rating)
 processReport (report@(Entity _ GameReport {..}), winnerPlayer@(Entity winnerId winner), loserPlayer@(Entity loserId loser)) = do

--- a/backend/src/Types/Api.hs
+++ b/backend/src/Types/Api.hs
@@ -25,7 +25,8 @@ data RawGameReport = RawGameReport
     aragornTurn :: Maybe Int,
     strongholds :: [Stronghold],
     interestRating :: Int,
-    comment :: Maybe Text
+    comment :: Maybe Text,
+    log :: Maybe Text
   }
   deriving (Generic, Show)
 
@@ -53,7 +54,8 @@ toGameReport timestamp winnerId loserId r =
       gameReportAragornTurn = r.aragornTurn,
       gameReportStrongholds = r.strongholds,
       gameReportInterestRating = r.interestRating,
-      gameReportComment = r.comment
+      gameReportComment = r.comment,
+      gameReportLog = r.log
     }
 
 data ProcessedGameReport = ProcessedGameReport
@@ -214,5 +216,3 @@ newtype DeleteReportRequest = DeleteReportRequest
   deriving (Generic)
 
 instance FromJSON DeleteReportRequest
-
--- TODO Game Logs

--- a/backend/src/Types/Api.hs
+++ b/backend/src/Types/Api.hs
@@ -3,8 +3,31 @@ module Types.Api where
 import Data.Aeson (FromJSON, ToJSON)
 import Data.Time (UTCTime)
 import Database.Esqueleto.Experimental (Entity (..))
+import Servant.Multipart (FromMultipart (..), MultipartData, Tmp)
 import Types.DataField (Competition, Expansion, League, Match, PlayerName, Rating, Side, Stronghold, Victory)
-import Types.Database (GameReport (..), GameReportId, Player (..), PlayerId, PlayerStats, PlayerStatsTotal (..), PlayerStatsYear (..), ReportInsertion)
+import Types.Database
+  ( GameReport (..),
+    GameReportId,
+    Player (..),
+    PlayerId,
+    PlayerStats,
+    PlayerStatsTotal (..),
+    PlayerStatsYear (..),
+    ReportInsertion,
+  )
+
+data SubmitReportRequest = SubmitReportRequest
+  { report :: PlayerId,
+    logFile :: FilePath
+  }
+  deriving (Generic)
+
+instance FromMultipart Tmp SubmitReportRequest where
+  fromMultipart :: MultipartData Tmp -> Either String SubmitReportRequest
+  fromMultipart multipartData = undefined
+
+-- User <$> lookupInput "username" multipartData
+--    <*> fmap fdPayload (lookupFile "pic" multipartData)
 
 data RawGameReport = RawGameReport
   { winner :: PlayerName,
@@ -32,8 +55,8 @@ data RawGameReport = RawGameReport
 
 instance FromJSON RawGameReport
 
-toGameReport :: UTCTime -> PlayerId -> PlayerId -> RawGameReport -> GameReport
-toGameReport timestamp winnerId loserId r =
+toGameReport :: UTCTime -> PlayerId -> PlayerId -> Maybe Text -> RawGameReport -> GameReport
+toGameReport timestamp winnerId loserId logFile r =
   GameReport
     { gameReportTimestamp = timestamp,
       gameReportWinnerId = winnerId,
@@ -55,7 +78,7 @@ toGameReport timestamp winnerId loserId r =
       gameReportStrongholds = r.strongholds,
       gameReportInterestRating = r.interestRating,
       gameReportComment = r.comment,
-      gameReportLog = r.log
+      gameReportLogFile = logFile
     }
 
 data ProcessedGameReport = ProcessedGameReport

--- a/backend/src/Types/Api.hs
+++ b/backend/src/Types/Api.hs
@@ -16,6 +16,8 @@ import Types.Database
     ReportInsertion,
   )
 
+type S3Path = Text
+
 data SubmitReportRequest = SubmitReportRequest
   { report :: RawGameReport,
     logFile :: FileData Tmp
@@ -58,7 +60,7 @@ data RawGameReport = RawGameReport
 
 instance FromJSON RawGameReport
 
-toGameReport :: UTCTime -> PlayerId -> PlayerId -> Maybe Text -> RawGameReport -> GameReport
+toGameReport :: UTCTime -> PlayerId -> PlayerId -> Maybe S3Path -> RawGameReport -> GameReport
 toGameReport timestamp winnerId loserId logFile r =
   GameReport
     { gameReportTimestamp = timestamp,

--- a/backend/src/Types/Api.hs
+++ b/backend/src/Types/Api.hs
@@ -16,7 +16,7 @@ import Types.Database
     ReportInsertion,
   )
 
-type S3Path = Text
+type S3Url = Text
 
 data SubmitReportRequest = SubmitReportRequest
   { report :: RawGameReport,
@@ -62,7 +62,7 @@ data RawGameReport = RawGameReport
 
 instance FromJSON RawGameReport
 
-toGameReport :: UTCTime -> PlayerId -> PlayerId -> Maybe S3Path -> RawGameReport -> GameReport
+toGameReport :: UTCTime -> PlayerId -> PlayerId -> Maybe S3Url -> RawGameReport -> GameReport
 toGameReport timestamp winnerId loserId logFile r =
   GameReport
     { gameReportTimestamp = timestamp,
@@ -112,7 +112,7 @@ data ProcessedGameReport = ProcessedGameReport
     strongholds :: [Stronghold],
     interestRating :: Int,
     comment :: Maybe Text,
-    logFile :: Maybe S3Path
+    logFile :: Maybe S3Url
   }
   deriving (Generic)
 

--- a/backend/src/Types/Api.hs
+++ b/backend/src/Types/Api.hs
@@ -55,8 +55,7 @@ data RawGameReport = RawGameReport
     aragornTurn :: Maybe Int,
     strongholds :: [Stronghold],
     interestRating :: Int,
-    comment :: Maybe Text,
-    log :: Maybe Text
+    comment :: Maybe Text
   }
   deriving (Generic, Show)
 

--- a/backend/src/Types/Database.hs
+++ b/backend/src/Types/Database.hs
@@ -41,6 +41,7 @@ share
     strongholds [Stronghold]
     interestRating Int
     comment Text Maybe
+    log Text Maybe
     deriving Show
 
    PlayerStatsYear

--- a/backend/src/Types/Database.hs
+++ b/backend/src/Types/Database.hs
@@ -41,7 +41,7 @@ share
     strongholds [Stronghold]
     interestRating Int
     comment Text Maybe
-    log Text Maybe
+    logFile Text Maybe
     deriving Show
 
    PlayerStatsYear

--- a/backend/src/Types/Migration.hs
+++ b/backend/src/Types/Migration.hs
@@ -153,7 +153,8 @@ data ParsedGameReport = ParsedGameReport
     aragornTurn :: Maybe Int,
     strongholds :: [Stronghold],
     interestRating :: Int,
-    comment :: Maybe Text
+    comment :: Maybe Text,
+    log :: Maybe Text
   }
 
 toParsedGameReport :: GameReportWithTrash -> ParsedGameReport
@@ -178,7 +179,8 @@ toParsedGameReport report =
       aragornTurn,
       strongholds,
       interestRating,
-      comment
+      comment,
+      log
     }
   where
     timestamp = case T.splitOn "/" (report.timestamp) of
@@ -334,6 +336,7 @@ toParsedGameReport report =
       where
         interest = fromMaybe 1 (readMaybe . toString $ report.gameRating)
     comment = report.gameComment
+    log = Nothing
 
 toRawGameReport :: ParsedGameReport -> RawGameReport
 toRawGameReport (ParsedGameReport {..}) = RawGameReport {..}

--- a/backend/wotr-community-website.cabal
+++ b/backend/wotr-community-website.cabal
@@ -39,6 +39,7 @@ common dependencies
         aeson               ^>=2.2.3.0,
         servant             ^>=0.20.2,
         servant-server      ^>=0.20.2,
+        servant-multipart   ^>=0.12.1,
         monad-logger        ^>=0.3.40,
         warp                ^>=3.4.7,
         persistent          ^>=2.14.6.3,

--- a/backend/wotr-community-website.cabal
+++ b/backend/wotr-community-website.cabal
@@ -53,6 +53,8 @@ common dependencies
         warp-tls            ^>=3.4.12,
         cassava             ^>=0.5.3.2,
         vector              ^>=0.13.2.0,
+        amazonka            ^>=2.0,
+        amazonka-s3         ^>=2.0,
 
 library
     import:           warnings,

--- a/infrastructure/lib/infrastructure-stack.ts
+++ b/infrastructure/lib/infrastructure-stack.ts
@@ -24,7 +24,7 @@ export class InfrastructureStack extends cdk.Stack {
         gameReportBucket.grantPublicAccess();
 
         this.website();
-        this.server(elasticIp);
+        this.server(elasticIp, gameReportBucket);
     }
 
     website() {
@@ -72,7 +72,7 @@ export class InfrastructureStack extends cdk.Stack {
         });
     }
 
-    server(elasticIp: ec2.CfnEIP) {
+    server(elasticIp: ec2.CfnEIP, gameReportBucket: s3.Bucket) {
         const ami = ec2.MachineImage.latestAmazonLinux2023();
 
         const vpc = new ec2.Vpc(this, "VPC", {
@@ -89,6 +89,7 @@ export class InfrastructureStack extends cdk.Stack {
         const role = new iam.Role(this, "ServerRole", {
             assumedBy: new iam.ServicePrincipal("ec2.amazonaws.com"),
         });
+        gameReportBucket.grantPut(role);
 
         const instance = new ec2.Instance(this, "ServerInstance", {
             instanceType: ec2.InstanceType.of(

--- a/infrastructure/lib/infrastructure-stack.ts
+++ b/infrastructure/lib/infrastructure-stack.ts
@@ -13,6 +13,16 @@ export class InfrastructureStack extends cdk.Stack {
 
         const elasticIp = new ec2.CfnEIP(this, "ElasticIP");
 
+        const gameReportBucket = new s3.Bucket(this, "GameReportBucket", {
+            blockPublicAccess: new s3.BlockPublicAccess({
+                blockPublicAcls: false,
+                blockPublicPolicy: false,
+                ignorePublicAcls: false,
+                restrictPublicBuckets: false,
+            }),
+        });
+        gameReportBucket.grantPublicAccess();
+
         this.website();
         this.server(elasticIp);
     }


### PR DESCRIPTION
![](https://media.giphy.com/media/FIPKX8nTQjNYI/giphy.gif?cid=ecf05e47vxls6dn3jjctxq9czh52pfi8a0jss6ytws5dtjze&ep=v1_gifs_search&rid=giphy.gif&ct=g)

Heck yeah let's gooo!

For frontend considerations, all that really matters is the API changes to `submitReport` and the associated request/response types.

As far as backend goes:
AWS actions operate with the help of an `Env` struct which I've now created during startup and then store in the Env of AppM. Once you're running, it's all just IO so pretty simple.

I've created a public readable bucket in our infrastructure - and the last thing I need to do is deploy putObject credentials to our host - the AWS library we're using should find those in the environment, but we'll need to test that actually happens.