### PR TITLE
Collect game log file in game report form

### DIFF
--- a/frontend/src/FileUpload.tsx
+++ b/frontend/src/FileUpload.tsx
@@ -5,22 +5,27 @@ import Button from "@mui/joy/Button";
 import ClearIcon from "@mui/icons-material/Close";
 import IconButton from "@mui/joy/IconButton";
 import Typography from "@mui/joy/Typography";
-import { MAX_GAME_LOG_SIZE_MB } from "./constants";
-
-const INPUT_ID = "game-log-upload";
 
 interface Props {
     value: File | null;
+    id: string;
+    constraintText: string;
     onChange: (file: File | null) => void;
     validate: () => void;
 }
 
-export default function FileUpload({ value, onChange, validate }: Props) {
+export default function FileUpload({
+    value,
+    id,
+    constraintText,
+    onChange,
+    validate,
+}: Props) {
     return (
         <Box>
             <Box display="flex" alignItems="center" gap={1}>
                 <input
-                    id={INPUT_ID}
+                    id={id}
                     style={{ display: "none" }}
                     type="file"
                     accept="text/plain"
@@ -30,7 +35,7 @@ export default function FileUpload({ value, onChange, validate }: Props) {
                     onBlur={validate}
                 />
 
-                <label htmlFor={INPUT_ID}>
+                <label htmlFor={id}>
                     <Button component="span" sx={{ whiteSpace: "nowrap" }}>
                         Choose file
                     </Button>
@@ -56,7 +61,7 @@ export default function FileUpload({ value, onChange, validate }: Props) {
             </Box>
 
             <Typography level="body-xs" mt={1}>
-                Max {MAX_GAME_LOG_SIZE_MB} MB
+                {constraintText}
             </Typography>
         </Box>
     );

--- a/frontend/src/FileUpload.tsx
+++ b/frontend/src/FileUpload.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+import Alert from "@mui/joy/Alert";
+import Box from "@mui/joy/Box";
+import Button from "@mui/joy/Button";
+import ClearIcon from "@mui/icons-material/Close";
+import IconButton from "@mui/joy/IconButton";
+import Typography from "@mui/joy/Typography";
+import { MAX_GAME_LOG_SIZE_MB } from "./constants";
+
+const INPUT_ID = "game-log-upload";
+
+interface Props {
+    value: File | null;
+    onChange: (file: File | null) => void;
+    validate: () => void;
+}
+
+export default function FileUpload({ value, onChange, validate }: Props) {
+    return (
+        <Box>
+            <Box display="flex" alignItems="center" gap={1}>
+                <input
+                    id={INPUT_ID}
+                    style={{ display: "none" }}
+                    type="file"
+                    accept="text/plain"
+                    onChange={(event) =>
+                        onChange(event.target.files?.[0] || null)
+                    }
+                    onBlur={validate}
+                />
+
+                <label htmlFor={INPUT_ID}>
+                    <Button component="span" sx={{ whiteSpace: "nowrap" }}>
+                        Choose file
+                    </Button>
+                </label>
+
+                {value && (
+                    <Alert color="success" sx={{ overflow: "hidden" }}>
+                        <Box
+                            sx={{
+                                display: "block",
+                                whiteSpace: "nowrap",
+                                overflow: "hidden",
+                                textOverflow: "ellipsis",
+                            }}
+                        >
+                            {value.name}
+                        </Box>
+                        <IconButton>
+                            <ClearIcon onClick={() => onChange(null)} />
+                        </IconButton>
+                    </Alert>
+                )}
+            </Box>
+
+            <Typography level="body-xs" mt={1}>
+                Max {MAX_GAME_LOG_SIZE_MB} MB
+            </Typography>
+        </Box>
+    );
+}

--- a/frontend/src/GameReportForm/index.tsx
+++ b/frontend/src/GameReportForm/index.tsx
@@ -538,25 +538,7 @@ function toFormData(unencodedPayload: GameReportPayload): FormData {
     const formData = new FormData();
 
     if (logFile) formData.append("logFile", logFile);
-
-    objectKeys(report).forEach((field) => {
-        const value = report[field];
-
-        if (value !== null) {
-            if (Array.isArray(value)) {
-                value.forEach((element, i) =>
-                    formData.append(`${field}[${i}]`, element)
-                );
-            } else if (
-                typeof value === "boolean" ||
-                typeof value === "number"
-            ) {
-                formData.append(field, value.toString());
-            } else {
-                formData.append(field, value);
-            }
-        }
-    });
+    formData.append("report", JSON.stringify(report));
 
     return formData;
 }

--- a/frontend/src/GameReportForm/index.tsx
+++ b/frontend/src/GameReportForm/index.tsx
@@ -15,6 +15,7 @@ import {
     leagues,
     matchTypes,
     MAX_GAME_LOG_SIZE_BYTES,
+    MAX_GAME_LOG_SIZE_MB,
     optionalFields,
     serverValidationErrors,
     sides,
@@ -464,6 +465,8 @@ function GameReportForm({ leaderboard, loadingLeaderboard }: Props) {
             >
                 <FileUpload
                     value={formData.logFile.value}
+                    id="game-log-upload"
+                    constraintText={`Max ${MAX_GAME_LOG_SIZE_MB} MB`}
                     validate={validateField("logFile")}
                     onChange={handleInputChange(
                         "logFile",

--- a/frontend/src/GameReportForm/initialFormData.tsx
+++ b/frontend/src/GameReportForm/initialFormData.tsx
@@ -1,6 +1,6 @@
-import { FormData } from "../types";
+import { GameFormData } from "../types";
 
-const initialFormData: FormData = {
+const initialFormData: GameFormData = {
     winner: {
         value: null,
         error: null,
@@ -104,6 +104,7 @@ const initialFormData: FormData = {
         validate: alwaysValid,
     },
     comment: { value: null, error: null, validate: alwaysValid },
+    logFile: { value: null, error: null, validate: alwaysValid },
 };
 
 export default initialFormData;

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -117,5 +117,5 @@ export enum ErrorMessage {
 
 export const INFINITE = 100;
 export const START_YEAR = 2023;
-export const MAX_GAME_LOG_SIZE_MB = 10;
+export const MAX_GAME_LOG_SIZE_MB = 1;
 export const MAX_GAME_LOG_SIZE_BYTES = MAX_GAME_LOG_SIZE_MB * 1024 * 1024;

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -51,7 +51,9 @@ export const strongholds = [
     "Erebor",
 ] as const;
 
-export const optionalFields = [
+export const optionalFormFields = ["logFile"] as const;
+
+export const optionalPayloadFields = [
     "competition",
     "league",
     "expansions",
@@ -64,8 +66,13 @@ export const optionalFields = [
     "comment",
 ] as const;
 
+export const optionalFields = [
+    ...optionalFormFields,
+    ...optionalPayloadFields,
+] as const;
+
 export const payloadFields = [
-    ...optionalFields,
+    ...optionalPayloadFields,
     "winner",
     "loser",
     "side",
@@ -110,3 +117,5 @@ export enum ErrorMessage {
 
 export const INFINITE = 100;
 export const START_YEAR = 2023;
+export const MAX_GAME_LOG_SIZE_MB = 10;
+export const MAX_GAME_LOG_SIZE_BYTES = MAX_GAME_LOG_SIZE_MB * 1024 * 1024;

--- a/frontend/src/hooks/useGameReportFormEffects.tsx
+++ b/frontend/src/hooks/useGameReportFormEffects.tsx
@@ -1,12 +1,12 @@
 import { useEffect } from "react";
-import { FormData, Stronghold, ValueOf } from "../types";
+import { GameFormData, Stronghold, ValueOf } from "../types";
 import { strongholds } from "../constants";
 import { isStrongholdInPlay } from "../utils";
 
 interface Args {
-    formData: FormData;
-    initialFormData: FormData;
-    setFormData: React.Dispatch<React.SetStateAction<FormData>>;
+    formData: GameFormData;
+    initialFormData: GameFormData;
+    setFormData: React.Dispatch<React.SetStateAction<GameFormData>>;
     successMessage: string | null;
 }
 
@@ -17,8 +17,8 @@ export default function useGameReportClearEffects({
     successMessage,
 }: Args) {
     const useControlledClearEffect = <
-        K extends keyof FormData,
-        V extends ValueOf<FormData>["value"]
+        K extends keyof GameFormData,
+        V extends ValueOf<GameFormData>["value"]
     >(
         controlField: V,
         clearField: K,

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -56,7 +56,7 @@ export type ConstrainedFormData<F> = {
     [K in keyof F]: F[K] extends FieldData<unknown> ? F[K] : never;
 };
 
-export interface FormData {
+export interface GameFormData {
     winner: FieldData<string | null>;
     loser: FieldData<string | null>;
     side: FieldData<Side | null>;
@@ -80,19 +80,23 @@ export interface FormData {
     strongholds: FieldData<Stronghold[]>;
     interestRating: FieldData<number | null>;
     comment: FieldData<string | null>;
+    logFile: FieldData<File | null>;
 }
 
-export type ValidFormData = {
-    [K in keyof FormData]: K extends OptionalField
-        ? FormData[K]
-        : { [J in keyof FormData[K]]: Exclude<FormData[K][J], null> };
+export type ValidGameFormData = {
+    [K in keyof GameFormData]: K extends OptionalField
+        ? GameFormData[K]
+        : { [J in keyof GameFormData[K]]: Exclude<GameFormData[K][J], null> };
 };
 
 export type GameReportPayload = {
-    [K in keyof Pick<ValidFormData, PayloadField>]: Pick<
-        ValidFormData,
-        PayloadField
-    >[K]["value"];
+    logFile: ValidGameFormData["logFile"]["value"];
+    report: {
+        [K in keyof Pick<ValidGameFormData, PayloadField>]: Pick<
+            ValidGameFormData,
+            PayloadField
+        >[K]["value"];
+    };
 };
 
 export interface LeaderboardEntry {


### PR DESCRIPTION
- Collect file in a form control, input optional
- Change the payload format to `{ report, logFile }`
- Encode the payload as multipart form data before sending to the server
- Our `FormData` type had a naming conflict with the `FormData` web API, so I renamed our type to `GameFormData` (and changed `ValidFormData` to `ValidGameFormData` to match)
- Add new option to the `useFormData` input handler to validate a field **before** accepting the input (since we want to reject a file greater than the allowed size)

~~Server responds with a 415, which might be because backend change isn't deployed OR because the frontend request format is wrong, but either way here's a PR so we can look at it!~~ Update: made a fix, now a request without a log file succeeds, and with a log file fails, but it's a 403 error from Amazon because I'm testing locally - so I think frontend is golden now!

Initial state:

![image](https://github.com/user-attachments/assets/1ab6c6f2-6eeb-4991-80bc-319e442df2ad)

Successfully uploaded file:

![image](https://github.com/user-attachments/assets/61c4a3e2-0c5b-4e65-9f0a-59fb3486f3a2)

File rejected due to size limit:

![image](https://github.com/user-attachments/assets/26c168f9-a2a8-4a10-a5ac-537c2815a633)