### PR TITLE
Game report deletion button

### DIFF
--- a/frontend/src/GameReportForm/index.tsx
+++ b/frontend/src/GameReportForm/index.tsx
@@ -70,6 +70,7 @@ function GameReportForm({ leaderboard, loadingLeaderboard }: Props) {
     ] = useFormData<GameFormData, ValidGameFormData>({
         initialFormData,
         optionalFields: optionalFields.slice(),
+        successMessageText: "Report submitted. Thank you!",
         submit,
         toErrorMessage,
     });

--- a/frontend/src/PlayerEditForm.tsx
+++ b/frontend/src/PlayerEditForm.tsx
@@ -8,13 +8,10 @@ import FormHelperText from "@mui/joy/FormHelperText";
 import FormLabel from "@mui/joy/FormLabel";
 import Sheet from "@mui/joy/Sheet";
 import Typography from "@mui/joy/Typography";
-import {
-    PlayerEditFormData,
-    ServerErrorBody,
-    ValidPlayerEditFormData,
-} from "./types";
+import { PlayerEditFormData, ValidPlayerEditFormData } from "./types";
 import TextInput from "./TextInput";
 import useFormData from "./hooks/useFormData";
+import { toErrorMessage } from "./utils";
 
 interface Props {
     pid: number;
@@ -136,11 +133,4 @@ function toPayload(formData: ValidPlayerEditFormData): PlayerRenamePayload {
         pid: formData.pid.value,
         newName: formData.newName.value,
     };
-}
-
-function toErrorMessage(error: ServerErrorBody): string {
-    if (error.status === 422) {
-        return error.response.data;
-    }
-    return "Something went wrong.";
 }

--- a/frontend/src/PlayerRemapForm.tsx
+++ b/frontend/src/PlayerRemapForm.tsx
@@ -12,12 +12,12 @@ import Typography from "@mui/joy/Typography";
 import {
     PlayerOption,
     PlayerRemapFormData,
-    ServerErrorBody,
     ValidPlayerRemapFormData,
 } from "./types";
 import Autocomplete from "./Autocomplete";
 import useFormData from "./hooks/useFormData";
 import { ErrorMessage } from "./constants";
+import { toErrorMessage } from "./utils";
 
 interface Props {
     pid: number;
@@ -169,11 +169,4 @@ function toPayload(
         fromPid: validFormData.fromPlayer.value.pid,
         toPid: validFormData.toPlayer.value.pid,
     };
-}
-
-function toErrorMessage(error: ServerErrorBody): string {
-    if (error.status === 422) {
-        return error.response.data;
-    }
-    return "Something went wrong.";
 }

--- a/frontend/src/ReportDeleteForm.tsx
+++ b/frontend/src/ReportDeleteForm.tsx
@@ -78,8 +78,8 @@ export default function ReportDeleteForm({
 
 async function submit({ rid }: ValidReportDeleteFormData) {
     return await axios.post(
-        // "https://api.waroftheringcommunity.net:8080/deleteReport",
-        "http://localhost:8081/deleteReport",
+        "https://api.waroftheringcommunity.net:8080/deleteReport",
+        // "http://localhost:8081/deleteReport",
         { rid: rid.value },
         { headers: { "Content-Type": "application/json" } }
     );

--- a/frontend/src/ReportDeleteForm.tsx
+++ b/frontend/src/ReportDeleteForm.tsx
@@ -1,0 +1,86 @@
+import axios from "axios";
+import React, { useEffect } from "react";
+import Box from "@mui/joy/Box";
+import Button from "@mui/joy/Button";
+import CircularProgress from "@mui/joy/CircularProgress";
+import Sheet from "@mui/joy/Sheet";
+import Typography from "@mui/joy/Typography";
+import useFormData from "./hooks/useFormData";
+import {
+    ProcessedGameReport,
+    ReportDeleteFormData,
+    ValidReportDeleteFormData,
+} from "./types";
+import { displayTime, toErrorMessage } from "./utils";
+
+interface Props {
+    report: ProcessedGameReport;
+    refresh: () => void;
+}
+
+export default function ReportDeleteForm({
+    report: { rid, winner, loser, timestamp },
+    refresh,
+}: Props) {
+    const [
+        _,
+        { errorOnSubmit, successMessage, loading: submitting },
+        { handleSubmit },
+    ] = useFormData<ReportDeleteFormData, ValidReportDeleteFormData>({
+        initialFormData: {
+            rid: { value: rid, error: null, validate: () => null },
+        },
+        optionalFields: [],
+        successMessageText: "Report deleted",
+        submit,
+        toErrorMessage,
+    });
+
+    useEffect(
+        function refreshOnSubmit() {
+            if (successMessage) refresh();
+        },
+        [successMessage]
+    );
+
+    return successMessage ? (
+        <Typography color="success">{successMessage}</Typography>
+    ) : (
+        <Sheet
+            sx={{
+                display: "flex",
+                flexDirection: "column",
+                alignItems: "center",
+                justifyContent: "center",
+                p: 2,
+                gap: 2,
+            }}
+        >
+            <Box>
+                Delete {displayTime(timestamp)} game between {winner} and{" "}
+                {loser}?
+            </Box>
+            <Button
+                onClick={handleSubmit}
+                disabled={submitting}
+                startDecorator={submitting ? <CircularProgress /> : undefined}
+            >
+                {submitting ? "Submitting..." : "Delete"}
+            </Button>
+            {errorOnSubmit && (
+                <Typography color="danger" mt={1}>
+                    {errorOnSubmit}
+                </Typography>
+            )}
+        </Sheet>
+    );
+}
+
+async function submit({ rid }: ValidReportDeleteFormData) {
+    return await axios.post(
+        // "https://api.waroftheringcommunity.net:8080/deleteReport",
+        "http://localhost:8081/deleteReport",
+        { rid: rid.value },
+        { headers: { "Content-Type": "application/json" } }
+    );
+}

--- a/frontend/src/hooks/useFormData/index.tsx
+++ b/frontend/src/hooks/useFormData/index.tsx
@@ -31,6 +31,7 @@ interface Args<F, V> {
     initialFormData: ConstrainedFormData<F>;
     optionalFields: string[];
     missingFieldErrorMessage?: ErrorMessage;
+    successMessageText?: string;
     submit: (validatedFormData: ConstrainedFormData<V>) => Promise<any>;
     toErrorMessage: (error: ServerErrorBody) => string;
 }
@@ -39,6 +40,7 @@ export default function useFormData<F, V extends F>({
     initialFormData,
     optionalFields,
     missingFieldErrorMessage = ErrorMessage.Required,
+    successMessageText = "Success",
     submit,
     toErrorMessage,
 }: Args<F, V>): [ConstrainedFormData<F>, Meta, Helpers<F>] {
@@ -139,7 +141,7 @@ export default function useFormData<F, V extends F>({
                 console.log("Form submitted successfully:", response);
                 // Handle the response data as needed
 
-                setSuccessMessage("Report submitted. Thank you!");
+                setSuccessMessage(successMessageText);
             }
         } catch (error) {
             console.error("Error submitting form:", error);

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -186,4 +186,19 @@ export type ValidPlayerRemapFormData = {
     };
 };
 
+export type ReportEditMode = "edit" | "delete";
+
+export interface ReportDeleteFormData {
+    rid: FieldData<number>;
+}
+
+export type ValidReportDeleteFormData = {
+    [K in keyof ReportDeleteFormData]: {
+        [J in keyof ReportDeleteFormData[K]]: Exclude<
+            ReportDeleteFormData[K][J],
+            null
+        >;
+    };
+};
+
 export type ValueOf<T> = T[keyof T];

--- a/frontend/src/utils.tsx
+++ b/frontend/src/utils.tsx
@@ -192,6 +192,17 @@ export function isServerError(error: unknown): error is ServerErrorBody {
     );
 }
 
+export function toErrorMessage(error: ServerErrorBody): string {
+    if (error.status === 422) {
+        return error.response.data;
+    }
+    return "Something went wrong.";
+}
+
+export function displayTime(timestamp: string) {
+    return Intl.DateTimeFormat("en-GB").format(new Date(Date.parse(timestamp)));
+}
+
 export function objectKeys<T extends object>(obj: T): Array<keyof T> {
     return Object.keys(obj) as Array<keyof T>;
 }


### PR DESCRIPTION
Even though there's no input from the user, I still treated the whole thing as a form, so the code will look familiar to the player edit/remap code. The form's data is the `rid`, and is populated when the user clicks the report's deletion button.

Includes a little bit of supporting cleanup:
- add a default `toErrorMessage` util
- add a `displayTime` util
- passing in the post-form-submission success text as an argument to `useFormData` because previously all the success messages were saying "Report submitted" - oops

