### PR TITLE
Remove mandatory migrate

### DIFF
--- a/backend/.vscode/settings.json
+++ b/backend/.vscode/settings.json
@@ -51,7 +51,8 @@
         "utct",
         "waroftheringcommunity",
         "wome",
-        "wotr"
+        "wotr",
+        "wotrcommunity"
     ],
     "cSpell.ignorePaths": [".vscode", "wotr-community-website.cabal"]
 }


### PR DESCRIPTION
![](https://media.giphy.com/media/ds9VVID0WdIqzBgLUT/giphy.gif?cid=790b7611960k6jsr8yu6s3lyv6n0agcpq1e8015i98yi5an1&ep=v1_gifs_search&rid=giphy.gif&ct=g)

Resolves #105 

* Migrations can now be run for the server by providing the "migrate" cmdline arg, but will not run otherwise
* Migrations always run for the Migration exe, but reduced duplication here
* Default set the AWS profile so we don't have to remember to do so

A little awkward that the migration script takes the whole environment when it only needs a logger and DB connection pool. But because of the way I structured the database operations as being inside `AppM` it can't be easily avoided. Not a huge deal, just annoying.