### PR TITLE
Support pagination for getReports API

### DIFF
--- a/backend/src/Api.hs
+++ b/backend/src/Api.hs
@@ -1,6 +1,17 @@
 module Api where
 
-import Servant (Get, JSON, Post, PostNoContent, QueryParam', ReqBody, Required, (:<|>), (:>))
+import Servant
+  ( Get,
+    JSON,
+    Post,
+    PostNoContent,
+    QueryParam,
+    QueryParam',
+    ReqBody,
+    Required,
+    (:<|>),
+    (:>),
+  )
 import Servant.Multipart (MultipartForm, Tmp)
 import Types.Api
   ( DeleteReportRequest,
@@ -16,7 +27,7 @@ import Types.Api
 
 type SubmitReportAPI = "submitReport" :> MultipartForm Tmp SubmitReportRequest :> Post '[JSON] SubmitGameReportResponse
 
-type GetReportsAPI = "reports" :> Get '[JSON] GetReportsResponse
+type GetReportsAPI = "reports" :> QueryParam "limit" Int64 :> QueryParam "offset" Int64 :> Get '[JSON] GetReportsResponse
 
 type GetLeaderboardAPI = "leaderboard" :> QueryParam' '[Required] "year" Int :> Get '[JSON] GetLeaderboardResponse
 

--- a/backend/src/AppServer.hs
+++ b/backend/src/AppServer.hs
@@ -198,8 +198,14 @@ submitReportHandler (SubmitReportRequest rawReport logFileData) = do
       mapM_ (putS3Object awsEnv key . fdPayload) logFileData
       pure SubmitGameReportResponse {report = processedReport, winnerRating, loserRating}
 
-getReportsHandler :: AppM GetReportsResponse
-getReportsHandler = runDb $ getGameReports 500 0 <&> GetReportsResponse . map fromGameReport
+getReportsHandler :: Maybe Int64 -> Maybe Int64 -> AppM GetReportsResponse
+getReportsHandler limit offset = GetReportsResponse . map fromGameReport <$> runDb (getGameReports limit' offset')
+  where
+    maxLimit = 500
+    (limit', offset') = case (limit, offset) of
+      (Nothing, _) -> (maxLimit, 0)
+      (Just lim, Nothing) -> (lim, 0)
+      (Just lim, Just off) -> (lim, off)
 
 getLeaderboardHandler :: Int -> AppM GetLeaderboardResponse
 getLeaderboardHandler year =


### PR DESCRIPTION
![](https://media.giphy.com/media/OEQg1LPjIX4wcNjNYR/giphy.gif?cid=790b76119qri5p97wov7bmh4iu7uayqxotlc0erb065382ve&ep=v1_gifs_search&rid=giphy.gif&ct=g)

Addresses the backend part of #112 

I can change this to a simpler query param of `page` that accepts just a number, but I figured the increased flexibility here might be nice, in case frontend would like to control how many results per page. LMK if you want it changed though!