### PR TITLE
Link to discord support in default error messages

### DIFF
--- a/frontend/src/AdminFormLayout.tsx
+++ b/frontend/src/AdminFormLayout.tsx
@@ -5,6 +5,7 @@ import CircularProgress from "@mui/joy/CircularProgress";
 import Sheet from "@mui/joy/Sheet";
 import Typography from "@mui/joy/Typography";
 import { FieldError } from "./types";
+import ErrorDisplay from "./ErrorDisplay";
 import FormElement from "./FormElement";
 
 interface FormElementProps {
@@ -85,9 +86,7 @@ export default function AdminFormLayout({
                     </Button>
 
                     {errorOnSubmit && (
-                        <Typography color="danger" mt={1}>
-                            {errorOnSubmit}
-                        </Typography>
+                        <ErrorDisplay message={errorOnSubmit} sx={{ mt: 1 }} />
                     )}
                 </>
             )}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,6 +15,7 @@ import ListItemButton from "@mui/joy/ListItemButton";
 import MenuIcon from "@mui/icons-material/Menu";
 import Typography from "@mui/joy/Typography";
 import { BrowserRouter, Routes, Route, Link } from "react-router-dom";
+import { ErrorMessage } from "./constants";
 import { HEADER_HEIGHT_PX, HEADER_MARGIN_PX } from "./styles/sizes";
 import { LeaderboardEntry } from "./types";
 
@@ -24,6 +25,9 @@ export default function App() {
         new Date().getFullYear()
     );
     const [loadingLeaderboard, setLoadingLeaderboard] = useState(false);
+    const [leaderboardError, setLeaderboardError] = useState<string | null>(
+        null
+    );
 
     const getLeaderboard = () => {
         setLoadingLeaderboard(true);
@@ -36,7 +40,10 @@ export default function App() {
             .then((response) => {
                 setLeaderboard(response.data.entries as LeaderboardEntry[]);
             })
-            .catch(console.error)
+            .catch((error) => {
+                setLeaderboardError(ErrorMessage.Default);
+                console.error(error);
+            })
             .finally(() => {
                 setLoadingLeaderboard(false);
             });
@@ -95,8 +102,10 @@ export default function App() {
                                 leaderboard={leaderboard}
                                 year={leaderboardYear}
                                 loading={loadingLeaderboard}
+                                error={leaderboardError}
                                 getLeaderboard={getLeaderboard}
                                 setYear={setLeaderboardYear}
+                                setError={setLeaderboardError}
                             />
                         }
                     />

--- a/frontend/src/ErrorDisplay.tsx
+++ b/frontend/src/ErrorDisplay.tsx
@@ -1,0 +1,26 @@
+import React, { ReactNode } from "react";
+import Typography from "@mui/joy/Typography";
+import ExternalLink from "./ExternalLink";
+import { SxProps } from "@mui/joy/styles/types";
+import { ErrorMessage } from "./constants";
+
+interface Props {
+    message: ReactNode;
+    sx?: SxProps;
+}
+
+export default function ErrorDisplay({ message, sx = {} }: Props) {
+    return (
+        <Typography color="danger" display="flex" alignItems="center" sx={sx}>
+            {message}
+            {message === ErrorMessage.Default && (
+                <ExternalLink
+                    href="https://discord.com/channels/590789678890745857/818775910748258326"
+                    style={{ paddingLeft: "4px" }}
+                >
+                    Discord support channel
+                </ExternalLink>
+            )}
+        </Typography>
+    );
+}

--- a/frontend/src/ExternalLink.tsx
+++ b/frontend/src/ExternalLink.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useEffect, useState } from "react";
+import React, { CSSProperties, ReactNode } from "react";
 import DownloadIcon from "@mui/icons-material/Download";
 import MuiLink from "@mui/joy/Link";
 import OpenInNewIcon from "@mui/icons-material/OpenInNew";
@@ -6,17 +6,24 @@ import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 interface ExternalLinkProps {
     href: string;
     isDownload?: boolean;
+    style?: CSSProperties;
     children: ReactNode;
 }
 
 export default function ExternalLink({
     href,
     isDownload = false,
+    style = {},
     children,
 }: ExternalLinkProps) {
     const Icon = isDownload ? DownloadIcon : OpenInNewIcon;
     return (
-        <MuiLink href={href} target="_blank" rel="noopener noreferrer">
+        <MuiLink
+            href={href}
+            target="_blank"
+            rel="noopener noreferrer"
+            style={style}
+        >
             <Icon sx={{ paddingRight: "5px" }} />
             {children}
         </MuiLink>

--- a/frontend/src/GameReportForm/index.tsx
+++ b/frontend/src/GameReportForm/index.tsx
@@ -41,6 +41,7 @@ import {
 } from "../utils";
 import useFormData from "../hooks/useFormData";
 import Autocomplete from "../Autocomplete";
+import ErrorDisplay from "../ErrorDisplay";
 import FileUpload from "../FileUpload";
 import FormElement from "../FormElement";
 import MultiOptionInput from "../MultiOptionInput";
@@ -482,9 +483,7 @@ function GameReportForm({ leaderboard, loadingLeaderboard }: Props) {
             >
                 {submitting ? "Submitting..." : "Submit"}
             </Button>
-            {errorOnSubmit && (
-                <Typography color="danger">{errorOnSubmit}</Typography>
-            )}
+            {errorOnSubmit && <ErrorDisplay message={errorOnSubmit} />}
         </Sheet>
     );
 }
@@ -550,7 +549,7 @@ function toErrorMessage(error: ServerErrorBody): string {
             );
         }
     }
-    return "Something went wrong.";
+    return ErrorMessage.Default;
 }
 
 function parseValidationResult(

--- a/frontend/src/GameReports.tsx
+++ b/frontend/src/GameReports.tsx
@@ -7,6 +7,7 @@ import Modal from "@mui/joy/Modal";
 import ModalClose from "@mui/joy/ModalClose";
 import ModalDialog from "@mui/joy/ModalDialog";
 import Typography from "@mui/joy/Typography";
+import { ErrorMessage } from "./constants";
 import {
     Competition,
     Expansion,
@@ -60,7 +61,7 @@ export default function GameReports() {
             );
             setReports(response.data.reports);
         } catch (error) {
-            setError("Something went wrong");
+            setError(ErrorMessage.Default);
             console.error(error);
         }
         setLoading(false);

--- a/frontend/src/Rankings.tsx
+++ b/frontend/src/Rankings.tsx
@@ -33,8 +33,10 @@ interface Props {
     leaderboard: LeaderboardEntry[];
     year: number;
     loading: boolean;
+    error: string | null;
     getLeaderboard: () => void;
     setYear: (year: number) => void;
+    setError: (error: string | null) => void;
 }
 
 const YEAR_SELECTOR_HEIGHT = 36;
@@ -51,11 +53,12 @@ function Rankings({
     leaderboard,
     year,
     loading,
+    error,
     getLeaderboard,
     setYear,
+    setError,
 }: Props) {
     const [filters, setFilters] = useState<PlayerState[]>(["Active"]);
-    const [error, setError] = useState<string | null>(null);
 
     const [playerEditParams, setPlayerEditParams] =
         useState<PlayerEditParams | null>(null);

--- a/frontend/src/TableLayout.tsx
+++ b/frontend/src/TableLayout.tsx
@@ -2,9 +2,9 @@ import React, { CSSProperties, ReactNode } from "react";
 import Box from "@mui/joy/Box";
 import Button from "@mui/joy/Button";
 import Table from "@mui/joy/Table";
-import Typography from "@mui/joy/Typography";
 import { SxProps } from "@mui/joy/styles/types";
 import { TABLE_BTN_HEIGHT_PX, TABLE_ELEMENTS_GAP } from "./styles/sizes";
+import ErrorDisplay from "./ErrorDisplay";
 
 interface Props {
     refresh: () => void;
@@ -70,7 +70,7 @@ export default function TableLayout({
                 </Box>
             )}
 
-            {error && <Typography color="danger">{error}</Typography>}
+            {error && <ErrorDisplay message={error} sx={{ pb: 2 }} />}
 
             {loading ? (
                 "Loading..."

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -109,6 +109,7 @@ export const serverValidationErrors = [
 export const playerStates = ["Active", "Inactive"] as const;
 
 export enum ErrorMessage {
+    Default = "Something went wrong. Please contact an admin for assistance.",
     Required = "Required",
     OnSubmit = "Could not submit, please resolve errors",
     MissingPlayerName = "This player does not exist in the database. Unless it's a new player, please check the spelling.",

--- a/frontend/src/hooks/useFormData.tsx
+++ b/frontend/src/hooks/useFormData.tsx
@@ -149,7 +149,7 @@ export default function useFormData<F, V extends F>({
             if (isServerError(error)) {
                 setErrorOnSubmit(toErrorMessage(error));
             } else {
-                setErrorOnSubmit("Something went wrong.");
+                setErrorOnSubmit(ErrorMessage.Default);
             }
         }
         setSubmitting(false);

--- a/frontend/src/utils.tsx
+++ b/frontend/src/utils.tsx
@@ -1,3 +1,4 @@
+import { ErrorMessage } from "./constants";
 import { Expansion, League, ServerErrorBody, Side, Stronghold } from "./types";
 
 export function strongholdSide(
@@ -196,7 +197,7 @@ export function toErrorMessage(error: ServerErrorBody): string {
     if (error.status === 422) {
         return error.response.data;
     }
-    return "Something went wrong.";
+    return ErrorMessage.Default;
 }
 
 export function displayTime(timestamp: string) {


### PR DESCRIPTION
Includes a bug fix, leaderboard loading error was getting swallowed - oops!

The discord support link will only display alongside our default "Something went wrong." If it's something besides the default, I like the given error message standing on its own, because the error is already telling you what's wrong/how to fix the problem directly. If you disagree let me know and I'll include the discord link across the board! Easy to change

Resolves #94

### Game form:
![image](https://github.com/user-attachments/assets/9efe9c90-d1ee-4810-b734-b864d6bd7614)

### Admin forms:
![image](https://github.com/user-attachments/assets/c8f6591e-40c8-4957-a718-6dbcebde696e)

### Table views:
![image](https://github.com/user-attachments/assets/eb7e44b6-4c56-4f64-90c0-cfcfd1db8cdd)