### PR TITLE
Support modificatin of report timestamp

### DIFF
--- a/backend/src/AppServer.hs
+++ b/backend/src/AppServer.hs
@@ -255,6 +255,7 @@ adminModifyReportHandler ModifyReportRequest {rid, timestamp, report} = case val
   where
     mustReprocess :: GameReport -> GameReport -> Bool
     mustReprocess old new
+      | old.gameReportTimestamp /= new.gameReportTimestamp = True
       | old.gameReportWinnerId /= new.gameReportWinnerId = True
       | old.gameReportLoserId /= new.gameReportLoserId = True
       | old.gameReportSide /= new.gameReportSide = True

--- a/backend/src/Types/Api.hs
+++ b/backend/src/Types/Api.hs
@@ -235,6 +235,7 @@ instance ToJSON RemapPlayerResponse
 
 data ModifyReportRequest = ModifyReportRequest
   { rid :: GameReportId,
+    timestamp :: Maybe UTCTime,
     report :: RawGameReport
   }
   deriving (Generic)


### PR DESCRIPTION
![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExa21scnc1YzQ3M3p6OTJtYWt3NDc5cjJwYWVvMGM0Mmt3bWg1OGNwbCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/vzjDaZlOgpIngatpEE/giphy.gif)

Resolves #116 

Reports being reported in the wrong order has been known to happen, so we should support modification of report timestamp along with everything else. I didn't do this initially because timestamp isn't part of a Raw Report (which was basically our input type), but it turned out to be simple enough to add.

Not sure how the UI should support this. If it's hard, we could punt there if need-be.

One note on the frontend side, [per the documentation](https://hackage.haskell.org/package/text-iso8601-0.1.1/docs/Data-Time-FromText.html#v:parseUTCTime) the valid string-serialized forms of a UTCTime are:

> YYYY-MM-DD HH:MMZ
YYYY-MM-DD HH:MM:SSZ
YYYY-MM-DD HH:MM:SS.SSSZ

> The first space may instead be a T, and the second space is optional. The Z represents UTC. The Z may be replaced with a time zone offset of the form +0000 or -08:00, where the first two digits are hours, the : is optional and the second two digits (also optional) are minutes.
