### PR TITLE
Create database indices

### DIFF
--- a/backend/src/AppServer.hs
+++ b/backend/src/AppServer.hs
@@ -10,6 +10,7 @@ import Data.Time (UTCTime (..), defaultTimeLocale, formatTime, getCurrentTime, t
 import Data.Validation (Validation (..))
 import Database
   ( DBAction,
+    SortOrder (..),
     deleteGameReport,
     deletePlayer,
     getAllGameReports,
@@ -180,8 +181,8 @@ processReport (report@(Entity _ GameReport {..}), winnerPlayer@(Entity winnerId 
 reprocessReports :: (MonadIO m, MonadLogger m) => DBAction m ()
 reprocessReports = do
   resetStats
-  reports <- getAllGameReports
-  forM_ (reverse reports) processReport
+  reports <- getAllGameReports OldestToNewest
+  forM_ reports processReport
   updateActiveStatus
 
 submitReportHandler :: SubmitReportRequest -> AppM SubmitGameReportResponse


### PR DESCRIPTION
![](https://media.giphy.com/media/3ohs7LbjnQH2ZxV11m/giphy.gif?cid=ecf05e477hy5z1ts6xg89e50480m6xamehcfop8in319b5pv&ep=v1_gifs_search&rid=giphy.gif&ct=g)

Resolves #120 

(Note, this change will require a database migration in addition to a deployment of the server binary. Someday would be nice to be able to do this programmatically, but it's fine for now).

After profiling the times, I wouldn't call it revolutionary, but definitely worth doing. Measured runtime of a full reprocess dropped from ~13 seconds to ~ 9 seconds, which is about a 30% improvement.

I believe we can call this good, until/unless we need additional perf. So the following is just my musings on that problem:

-- 

Of the 9 seconds taken by a reprocess, they're split 4 / 5 between reading reports and processing them respectively. The 4 second time on reading is interesting, because it can't be reduced very easily with our current storage patterns, and is heavily CPU bound (the same operation takes ~1 second on my personal machine). The "next step" here would be the ability to only reprocess those games that happened AFTER the game where the edit occurred (this would make a reprocess entirely negligible, since most reprocessing is done on reports from the last month or two at most). To do this, we would have to revise how we store player stats - which would eventually amount to some kind of tradeoff between runtime and storage space. I think this would be a good thing to investigate - we would have to proceed carefully to make sure we don't impact fast display of the leaderboard.