### PR TITLE
Logfile Validation

### DIFF
--- a/backend/app/Server.hs
+++ b/backend/app/Server.hs
@@ -15,6 +15,7 @@ import Network.Wai.Middleware.Cors (CorsResourcePolicy (..), cors)
 import Network.Wai.Middleware.Gzip (defaultGzipSettings, gzip)
 import Network.Wai.Parse (defaultParseRequestBodyOptions, setMaxRequestFileSize)
 import Servant (Application, Context (..), hoistServer, serveWithContext)
+import Servant.Multipart (MultipartOptions (..), Tmp, defaultMultipartOptions)
 import System.Directory (createDirectoryIfMissing)
 import System.Environment (setEnv)
 import System.FilePath (takeDirectory)
@@ -44,7 +45,11 @@ app :: Env -> Application
 app env = gzipMiddleware . corsMiddleware . serveWithContext api context . hoistServer api (nt env) $ server
   where
     maxSizeBytes = maxGameLogSizeMB * 1024 * 1024
-    multipartOpts = setMaxRequestFileSize maxSizeBytes defaultParseRequestBodyOptions
+    multipartOpts :: MultipartOptions Tmp
+    multipartOpts =
+      (defaultMultipartOptions (Proxy :: Proxy Tmp))
+        { generalOptions = setMaxRequestFileSize maxSizeBytes defaultParseRequestBodyOptions
+        }
     context = multipartOpts :. EmptyContext
 
 main :: IO ()

--- a/backend/app/Server.hs
+++ b/backend/app/Server.hs
@@ -2,7 +2,7 @@ module Main where
 
 import Amazonka qualified as AWS
 import Api (api)
-import AppConfig (Env (..), databaseFile, logFile, nt, redisConfig, runAppLogger)
+import AppConfig (Env (..), databaseFile, logFile, maxGameLogSizeMB, nt, redisConfig, runAppLogger)
 import AppServer (server)
 import Control.Monad.Logger (LogLevel (..))
 import Database.Esqueleto.Experimental (defaultConnectionPoolConfig)
@@ -13,8 +13,8 @@ import Network.Wai.Handler.Warp (defaultSettings, setPort)
 import Network.Wai.Handler.WarpTLS (runTLS, tlsSettings)
 import Network.Wai.Middleware.Cors (CorsResourcePolicy (..), cors)
 import Network.Wai.Middleware.Gzip (defaultGzipSettings, gzip)
-import Servant (Application, hoistServer)
-import Servant.Server (serve)
+import Network.Wai.Parse (defaultParseRequestBodyOptions, setMaxRequestFileSize)
+import Servant (Application, Context (..), hoistServer, serveWithContext)
 import System.Directory (createDirectoryIfMissing)
 import System.Environment (setEnv)
 import System.FilePath (takeDirectory)
@@ -41,7 +41,11 @@ gzipMiddleware :: Middleware
 gzipMiddleware = gzip defaultGzipSettings
 
 app :: Env -> Application
-app env = gzipMiddleware . corsMiddleware . serve api . hoistServer api (nt env) $ server
+app env = gzipMiddleware . corsMiddleware . serveWithContext api context . hoistServer api (nt env) $ server
+  where
+    maxSizeBytes = maxGameLogSizeMB * 1024 * 1024
+    multipartOpts = setMaxRequestFileSize maxSizeBytes defaultParseRequestBodyOptions
+    context = multipartOpts :. EmptyContext
 
 main :: IO ()
 main = do

--- a/backend/src/AppConfig.hs
+++ b/backend/src/AppConfig.hs
@@ -19,6 +19,9 @@ databaseFile = "data/db.sqlite"
 logFile :: FilePath
 logFile = "logs/app.log"
 
+maxGameLogSizeMB :: Int64
+maxGameLogSizeMB = 1
+
 gameLogBucket :: S3.BucketName
 gameLogBucket = "infrastructurestack-gamereportbucket21a257d2-v7okzv3x39a9"
 

--- a/backend/src/AppServer.hs
+++ b/backend/src/AppServer.hs
@@ -62,7 +62,7 @@ import Types.Database
     updatedPlayerStatsLose,
     updatedPlayerStatsWin,
   )
-import Validation (validateReport)
+import Validation (validateLogFile, validateReport)
 import Prelude hiding (get, on)
 
 defaultRating :: Rating
@@ -187,6 +187,9 @@ reprocessReports = do
 submitReportHandler :: SubmitReportRequest -> AppM SubmitGameReportResponse
 submitReportHandler (SubmitReportRequest rawReport logFileData) = do
   awsEnv <- asks aws
+
+  whenJust logFileData (validateLogFile . fdPayload)
+
   case validateReport rawReport of
     Failure errors -> throwError $ err422 {errBody = show errors}
     Success (RawGameReport {..}) -> runDb $ do

--- a/backend/wotr-community-website.cabal
+++ b/backend/wotr-community-website.cabal
@@ -33,6 +33,7 @@ common dependencies
     build-depends:
         base                ^>=4.20.0.0,
         relude              ^>=1.2.2.0,
+        text                ^>=2.1.2,
         filepath            ^>=1.5.4.0,
         directory           ^>=1.3.9.0,
         time                ^>=1.12.2,

--- a/frontend/src/FileUpload.tsx
+++ b/frontend/src/FileUpload.tsx
@@ -28,6 +28,7 @@ export default function FileUpload({
                     id={id}
                     style={{ display: "none" }}
                     type="file"
+                    accept=".log,text/plain"
                     onChange={(event) =>
                         onChange(event.target.files?.[0] || null)
                     }


### PR DESCRIPTION
![](https://media.giphy.com/media/Zvgb12U8GNjvq/giphy.gif?cid=790b7611z4gbgkpgkg0dppt0s3ijt8r9ec915ofe9ziucr5s&ep=v1_gifs_search&rid=giphy.gif&ct=g)

Resolves #134 

Certainly not bulletproof, but I would argue good enough for now.

* On the frontent, accept text/plain or *.log extension files as input (I checked and confirmed it is Mac-specific nonsense going on with the logs. It knows they are text/plain, but browsers on Mac don't only get the MIME type. Mac has some notion of "hierarchy" that the browser is not aware of.)

* Block uploads > 1MB on the server

* Do a little bit of parsing validation on the backend, check at least for the header that should be present in all logs