### PR TITLE
Game reports frontend pagination

### DIFF
--- a/backend/src/AppServer.hs
+++ b/backend/src/AppServer.hs
@@ -19,6 +19,7 @@ import Database
     getAllGameReports,
     getAllStats,
     getGameReports,
+    getNumGameReports,
     getPlayerByName,
     getPlayerStats,
     insertGameReport,
@@ -256,9 +257,9 @@ submitReportHandler (SubmitReportRequest rawReport logFileData) = do
 
 getReportsHandler :: Maybe Int64 -> Maybe Int64 -> AppM GetReportsResponse
 getReportsHandler limit offset = do
-    allReports <- runDb (getAllGameReports OldestToNewest)
+    total <- runDb getNumGameReports
     reports <- runDb (getGameReports limit' offset')
-    pure GetReportsResponse {reports = fromGameReport <$> reports, total = length allReports}
+    pure GetReportsResponse {reports = fromGameReport <$> reports, total}
     where
       maxLimit = 500
       (limit', offset') = case (limit, offset) of

--- a/backend/src/AppServer.hs
+++ b/backend/src/AppServer.hs
@@ -53,7 +53,7 @@ import Servant.Server.Experimental.Auth (AuthServerData)
 import Types.Api
   ( DeleteReportRequest (..),
     GetLeaderboardResponse (GetLeaderboardResponse),
-    GetReportsResponse (GetReportsResponse),
+    GetReportsResponse (..),
     GoogleLoginResponse,
     IdToken,
     LeaderboardEntry (..),
@@ -255,13 +255,16 @@ submitReportHandler (SubmitReportRequest rawReport logFileData) = do
       pure SubmitGameReportResponse {report = processedReport, winnerRating, loserRating}
 
 getReportsHandler :: Maybe Int64 -> Maybe Int64 -> AppM GetReportsResponse
-getReportsHandler limit offset = GetReportsResponse . map fromGameReport <$> runDb (getGameReports limit' offset')
-  where
-    maxLimit = 500
-    (limit', offset') = case (limit, offset) of
-      (Nothing, _) -> (maxLimit, 0)
-      (Just lim, Nothing) -> (lim, 0)
-      (Just lim, Just off) -> (lim, off)
+getReportsHandler limit offset = do
+    allReports <- runDb (getAllGameReports OldestToNewest)
+    reports <- runDb (getGameReports limit' offset')
+    pure GetReportsResponse {reports = fromGameReport <$> reports, total = length allReports}
+    where
+      maxLimit = 500
+      (limit', offset') = case (limit, offset) of
+        (Nothing, _) -> (maxLimit, 0)
+        (Just lim, Nothing) -> (lim, 0)
+        (Just lim, Just off) -> (lim, off)
 
 getLeaderboardHandler :: Maybe Year -> AppM GetLeaderboardResponse
 getLeaderboardHandler year = do

--- a/backend/src/AppServer.hs
+++ b/backend/src/AppServer.hs
@@ -256,10 +256,10 @@ submitReportHandler (SubmitReportRequest rawReport logFileData) = do
       pure SubmitGameReportResponse {report = processedReport, winnerRating, loserRating}
 
 getReportsHandler :: Maybe Int64 -> Maybe Int64 -> AppM GetReportsResponse
-getReportsHandler limit offset = do
-    total <- runDb getNumGameReports
-    reports <- runDb (getGameReports limit' offset')
-    pure GetReportsResponse {reports = fromGameReport <$> reports, total}
+getReportsHandler limit offset =
+    runDb getNumGameReports >>= \total ->
+      runDb (getGameReports limit' offset') >>= \reports ->
+        pure GetReportsResponse {reports = fromGameReport <$> reports, total}
     where
       maxLimit = 500
       (limit', offset') = case (limit, offset) of

--- a/backend/src/Types/Api.hs
+++ b/backend/src/Types/Api.hs
@@ -170,7 +170,11 @@ data SubmitGameReportResponse = SubmitGameReportResponse
 
 instance ToJSON SubmitGameReportResponse
 
-newtype GetReportsResponse = GetReportsResponse {reports :: [ProcessedGameReport]} deriving (Generic)
+data GetReportsResponse = GetReportsResponse
+  { reports :: [ProcessedGameReport],
+    total :: Int
+  }
+  deriving (Generic)
 
 instance ToJSON GetReportsResponse
 

--- a/frontend/src/Pagination.tsx
+++ b/frontend/src/Pagination.tsx
@@ -1,0 +1,128 @@
+import React, { useState } from "react";
+import Box from "@mui/joy/Box";
+import ChevronLeft from "@mui/icons-material/ChevronLeft";
+import ChevronRight from "@mui/icons-material/ChevronRight";
+import IconButton from "@mui/joy/IconButton";
+import { range } from "./utils";
+
+interface Props {
+    currentPage: number;
+    setCurrentPage: (page: number) => void;
+    totalCount: number;
+    perPageCount: number;
+    slots?: number;
+    minSpanEachSide?: number;
+}
+
+export default function Pagination({
+    currentPage,
+    setCurrentPage,
+    totalCount,
+    perPageCount,
+    slots = 7,
+    minSpanEachSide = 2,
+}: Props) {
+    const pageCount = Math.ceil(totalCount / perPageCount);
+    const pageRanges = toPageRanges(
+        currentPage,
+        pageCount,
+        slots,
+        minSpanEachSide
+    );
+
+    return (
+        <Box
+            display="flex"
+            flexDirection="row"
+            alignItems="center"
+            justifyContent="center"
+            width="100%"
+            overflow="auto"
+        >
+            <IconButton
+                disabled={currentPage === 1}
+                onClick={() => setCurrentPage(currentPage - 1)}
+                variant="plain"
+            >
+                <ChevronLeft />
+            </IconButton>
+
+            {pageRanges.map((pageRange, i) => (
+                <React.Fragment key={pageRange.join()}>
+                    {pageRange.map((page) => (
+                        <PageButton
+                            key={page}
+                            value={page}
+                            onClick={() => setCurrentPage(page)}
+                            selected={currentPage === page}
+                        />
+                    ))}
+                    {i !== pageRanges.length - 1 && <PageButton value="..." />}
+                </React.Fragment>
+            ))}
+
+            <IconButton
+                disabled={currentPage === pageCount}
+                onClick={() => setCurrentPage(currentPage + 1)}
+                variant="plain"
+            >
+                <ChevronRight />
+            </IconButton>
+        </Box>
+    );
+}
+
+interface PageButtonProps {
+    value: number | string;
+    selected?: boolean;
+    onClick?: () => void;
+}
+
+function PageButton({ value, selected, onClick }: PageButtonProps) {
+    return (
+        <IconButton
+            disabled={!onClick}
+            onClick={onClick}
+            variant={selected ? "solid" : "plain"}
+            color={selected ? "primary" : "neutral"}
+            sx={{ mx: "1px" }}
+        >
+            {value}
+        </IconButton>
+    );
+}
+
+function toPageRanges(
+    current: number,
+    final: number,
+    slots: number,
+    minSpanEachSide: number
+): number[][] {
+    const oneSidedSpan = slots - minSpanEachSide;
+    const endThreshold = final - oneSidedSpan + 1;
+
+    const middleSpanExcludingCurrent = slots - minSpanEachSide * 2 - 1;
+    const leftSpan = Math.ceil(middleSpanExcludingCurrent / 2);
+    const rightSpan = Math.floor(middleSpanExcludingCurrent / 2);
+
+    if (
+        final > slots &&
+        current > 0 &&
+        current <= final &&
+        minSpanEachSide * 2 <= final
+    ) {
+        if (current < oneSidedSpan) {
+            return [range(1, oneSidedSpan + 1), [final]];
+        } else if (current > endThreshold) {
+            return [[1], range(endThreshold, final + 1)];
+        } else {
+            return [
+                [1],
+                range(current - leftSpan, current + rightSpan + 1),
+                [final],
+            ];
+        }
+    }
+
+    return [range(1, final + 1)];
+}


### PR DESCRIPTION
I touched the backend, sorry to intrude, felt super out of my depth 😬 I needed the total record count and did it inefficiently by calling `getAllGameReports`, which throws away any backend time savings from pagination. Hoping you can help me fix it?

Anyway, the main frontend part is the `Pagination` component! Not too complicated but the logic for displaying page ranges split by the `...`s was fun.

I did local testing by mocking props and the total page count mostly; once the server code is synced up I'll definitely do real-life testing to make sure page numbers are for sure lining up with reports.

![image](https://github.com/user-attachments/assets/8d3828a7-405a-43a1-bbc9-54128d6d2cb6)

![image](https://github.com/user-attachments/assets/fb9dae18-aaa0-4063-951c-596014555d6c)

![image](https://github.com/user-attachments/assets/a4384479-850c-4ce2-8f1e-7dae663b39a2)
