### PR TITLE
Logout and UserInfo endpoints

### DIFF
--- a/backend/src/Api.hs
+++ b/backend/src/Api.hs
@@ -1,6 +1,5 @@
 module Api where
 
-import Auth (SessionIdCookie)
 import Servant
   ( AuthProtect,
     Get,
@@ -28,9 +27,15 @@ import Types.Api
     RenamePlayerRequest,
     SubmitGameReportResponse,
     SubmitReportRequest,
+    UserInfoResponse,
   )
+import Types.Auth (SessionIdCookie)
 
 type AuthGoogleLoginAPI = "auth" :> "google" :> "login" :> ReqBody '[PlainText] IdToken :> Verb 'POST 204 '[JSON] GoogleLoginResponse
+
+type LogoutAPI = "logout" :> PostNoContent
+
+type UserInfoAPI = "userInfo" :> Get '[JSON] UserInfoResponse
 
 type SubmitReportAPI =
   "submitReport" :> MultipartForm Tmp SubmitReportRequest :> Post '[JSON] SubmitGameReportResponse
@@ -53,8 +58,6 @@ type AdminModifyReportAPI =
 type AdminDeleteReportAPI =
   "deleteReport" :> ReqBody '[JSON] DeleteReportRequest :> PostNoContent
 
--- TODO Add logout and logged-in verification APIs
-
 type Unprotected =
   AuthGoogleLoginAPI
     :<|> SubmitReportAPI
@@ -62,7 +65,9 @@ type Unprotected =
     :<|> GetLeaderboardAPI
 
 type Protected =
-  AdminRenamePlayerAPI
+  LogoutAPI
+    :<|> UserInfoAPI
+    :<|> AdminRenamePlayerAPI
     :<|> AdminRemapPlayerAPI
     :<|> AdminModifyReportAPI
     :<|> AdminDeleteReportAPI

--- a/backend/src/Types/Api.hs
+++ b/backend/src/Types/Api.hs
@@ -29,6 +29,10 @@ instance MimeUnrender PlainText IdToken where
 -- Defining here to reduce verbosity, needed to work around https://github.com/haskell-servant/servant/issues/1267
 type GoogleLoginResponse = Headers '[Header "Set-Cookie" SetCookie] NoContent
 
+newtype UserInfoResponse = UserInfoResponse {isAdmin :: Bool} deriving (Generic)
+
+instance ToJSON UserInfoResponse
+
 data SubmitReportRequest = SubmitReportRequest
   { report :: RawGameReport,
     logFile :: Maybe (FileData Tmp)

--- a/backend/src/Types/Auth.hs
+++ b/backend/src/Types/Auth.hs
@@ -4,7 +4,7 @@ import Data.Aeson (FromJSON)
 import Servant (AuthProtect)
 import Servant.Server.Experimental.Auth (AuthServerData)
 
-data SessionIdCookie = SessionIdCookie -- Type-level tag for the auth scheme
+data SessionIdCookie = Proxy -- Type-level tag for the auth scheme
 
 type instance AuthServerData (AuthProtect SessionIdCookie) = Authenticated
 

--- a/backend/src/Types/Auth.hs
+++ b/backend/src/Types/Auth.hs
@@ -1,0 +1,29 @@
+module Types.Auth where
+
+import Data.Aeson (FromJSON)
+import Servant (AuthProtect)
+import Servant.Server.Experimental.Auth (AuthServerData)
+
+data SessionIdCookie = SessionIdCookie -- Type-level tag for the auth scheme
+
+type instance AuthServerData (AuthProtect SessionIdCookie) = Authenticated
+
+newtype UserId = UserId {unUserId :: Text}
+
+newtype SessionId = SessionId {unSessionId :: Text}
+
+data Authenticated = Authenticated {userId :: UserId, sessionId :: SessionId}
+
+data GoogleIdTokenClaims = GoogleIdTokenClaims
+  { iss :: Text,
+    sub :: Text,
+    aud :: Text,
+    hd :: Maybe Text,
+    exp :: Integer,
+    iat :: Integer,
+    email :: Text,
+    email_verified :: Bool
+  }
+  deriving (Generic)
+
+instance FromJSON GoogleIdTokenClaims

--- a/backend/wotr-community-website.cabal
+++ b/backend/wotr-community-website.cabal
@@ -75,6 +75,7 @@ library
                       Database,
                       Logging,
                       Types.Api,
+                      Types.Auth,
                       Types.Database,
                       Types.DataField,
                       Types.Migration,


### PR DESCRIPTION
![](https://media.giphy.com/media/QhmboW0R7eUbm/giphy.gif?cid=790b7611xtwnnt8r7ya0bhtwipbfr67cdzbylwqqjj7kdba9&ep=v1_gifs_search&rid=giphy.gif&ct=g)

Finishes up the loose-ends from the initial auth PR

**Main additions**
* Logout API
* UserInfo API

`/logout` just nulls the sessionId in the auth database (recall that this is checked every time a protected action is attempted)

`/userInfo` returns a UserInfo response type... although this is quite boring at present, consisting of only a single `isAdmin` boolean - which should always be True if you get a successful response at all. We can use this to determine whether or not to show the admin controls on the page. The response can also be updated with more user info in the future, if that's ever needed.

**Other Refactor and Cleanup**
* Auth types moved to their own module, this solves some layering issues I had previously
* `UserId` and `SessionId` type aliases are now proper newtypes for better type safety
* Auth handler now passes along the authenticated user information to any protected handlers that need it (currently only `userInfoHandler` does)
* UUID values are handled more consistently

