### PR TITLE
Display auth status in app header

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,6 +18,7 @@ import MenuIcon from "@mui/icons-material/Menu";
 import Typography from "@mui/joy/Typography";
 import { BrowserRouter, Routes, Route, Link } from "react-router-dom";
 import { ErrorMessage } from "./constants";
+import { logNetworkError } from "./networkErrorHandlers";
 import { HEADER_HEIGHT_PX, HEADER_MARGIN_PX } from "./styles/sizes";
 import { LeaderboardEntry, UserInfo } from "./types";
 import { GoogleOAuthProvider } from "@react-oauth/google";
@@ -42,7 +43,7 @@ export default function App() {
             // .get("http://localhost:8081/userInfo")
             .get("https://api.waroftheringcommunity.net:8080/userInfo")
             .then((response) => setUserInfo(response.data))
-            .catch(console.error)
+            .catch(logNetworkError)
             .finally(() => setLoadingUserInfo(false));
     };
 
@@ -59,7 +60,7 @@ export default function App() {
             })
             .catch((error) => {
                 setLeaderboardError(ErrorMessage.Default);
-                console.error(error);
+                logNetworkError(error);
             })
             .finally(() => {
                 setLoadingLeaderboard(false);

--- a/frontend/src/GameReportForm/index.tsx
+++ b/frontend/src/GameReportForm/index.tsx
@@ -25,6 +25,7 @@ import {
     victoryTypes,
 } from "../constants";
 import { GAME_FORM_BOLD } from "../styles/colors";
+import { toErrorMessage } from "../networkErrorHandlers";
 import {
     GameFormData,
     GameReportPayload,
@@ -41,7 +42,6 @@ import {
     getStrongholdLabel,
     isStrongholdInPlay,
     strongholdSide,
-    toErrorMessage,
 } from "../utils";
 import useFormData from "../hooks/useFormData";
 import Autocomplete from "../Autocomplete";

--- a/frontend/src/GameReports.tsx
+++ b/frontend/src/GameReports.tsx
@@ -22,6 +22,7 @@ import {
     Victory,
 } from "./types";
 import { FREE_ACCENT_COLOR, SHADOW_PRIMARY_COLOR } from "./styles/colors";
+import { logNetworkError } from "./networkErrorHandlers";
 import {
     HEADER_HEIGHT_PX,
     HEADER_MARGIN_PX,
@@ -87,7 +88,7 @@ export default function GameReports({
             setTotalReportCount(response.data.total);
         } catch (error) {
             setError(ErrorMessage.Default);
-            console.error(error);
+            logNetworkError(error);
         }
         setLoading(false);
     };

--- a/frontend/src/GoogleLogin.tsx
+++ b/frontend/src/GoogleLogin.tsx
@@ -2,7 +2,11 @@ import React from "react";
 import { CredentialResponse, GoogleLogin } from "@react-oauth/google";
 import axios from "axios";
 
-export default function GoogleLoginButton() {
+interface Props {
+    getUserInfo: () => void;
+}
+
+export default function GoogleLoginButton({ getUserInfo }: Props) {
     const handleLoginSuccess = async (response: CredentialResponse) => {
         await axios
             .post(
@@ -10,6 +14,7 @@ export default function GoogleLoginButton() {
                 response.credential,
                 { headers: { "Content-Type": "text/plain;charset=utf-8" } }
             )
+            .then(getUserInfo)
             .catch((error) => {
                 console.error(error);
             });

--- a/frontend/src/GoogleLogin.tsx
+++ b/frontend/src/GoogleLogin.tsx
@@ -1,28 +1,48 @@
 import React from "react";
 import { CredentialResponse, GoogleLogin } from "@react-oauth/google";
 import axios from "axios";
-import { logNetworkError } from "./networkErrorHandlers";
+import { ErrorMessage } from "./constants";
+import { logNetworkError, toAuthStatus } from "./networkErrorHandlers";
 
 interface Props {
-    getUserInfo: () => void;
+    getUserInfo: (onError: (error: unknown) => void) => void;
+    clearUserInfo: () => void;
+    setLoginError: (error: string) => void;
+    setLoadingUserInfo: (loading: boolean) => void;
 }
 
-export default function GoogleLoginButton({ getUserInfo }: Props) {
+export default function GoogleLoginButton({
+    getUserInfo,
+    clearUserInfo,
+    setLoginError,
+    setLoadingUserInfo,
+}: Props) {
+    const onError = (error: unknown) => {
+        logNetworkError(error);
+        setLoginError(toAuthStatus(error));
+        clearUserInfo();
+    };
+
     const handleLoginSuccess = async (response: CredentialResponse) => {
+        setLoadingUserInfo(true);
         await axios
             .post(
+                // "http://localhost:8081/auth/google/login",
                 "https://api.waroftheringcommunity.net:8080/auth/google/login",
                 response.credential,
                 { headers: { "Content-Type": "text/plain;charset=utf-8" } }
             )
-            .then(getUserInfo)
-            .catch(logNetworkError);
+            .then(() => getUserInfo(onError))
+            .catch((error) => {
+                onError(error);
+                setLoadingUserInfo(false);
+            });
     };
 
     return (
         <GoogleLogin
             onSuccess={handleLoginSuccess}
-            onError={() => console.log("Error logging in.")}
+            onError={() => setLoginError(ErrorMessage.NotAuthorizedStatus)}
         />
     );
 }

--- a/frontend/src/GoogleLogin.tsx
+++ b/frontend/src/GoogleLogin.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { CredentialResponse, GoogleLogin } from "@react-oauth/google";
 import axios from "axios";
+import { logNetworkError } from "./networkErrorHandlers";
 
 interface Props {
     getUserInfo: () => void;
@@ -15,9 +16,7 @@ export default function GoogleLoginButton({ getUserInfo }: Props) {
                 { headers: { "Content-Type": "text/plain;charset=utf-8" } }
             )
             .then(getUserInfo)
-            .catch((error) => {
-                console.error(error);
-            });
+            .catch(logNetworkError);
     };
 
     return (

--- a/frontend/src/PlayerEditForm.tsx
+++ b/frontend/src/PlayerEditForm.tsx
@@ -5,7 +5,7 @@ import AdminFormLayout from "./AdminFormLayout";
 import TextInput from "./TextInput";
 import useConditionalActionEffect from "./hooks/useConditionalActionEffect";
 import useFormData, { initializeToDefaults } from "./hooks/useFormData";
-import { toErrorMessage } from "./utils";
+import { toErrorMessage } from "./networkErrorHandlers";
 
 interface Props {
     pid: number;

--- a/frontend/src/PlayerRemapForm.tsx
+++ b/frontend/src/PlayerRemapForm.tsx
@@ -11,7 +11,7 @@ import Autocomplete from "./Autocomplete";
 import useConditionalActionEffect from "./hooks/useConditionalActionEffect";
 import useFormData, { initializeToDefaults } from "./hooks/useFormData";
 import { ErrorMessage } from "./constants";
-import { toErrorMessage } from "./utils";
+import { toErrorMessage } from "./networkErrorHandlers";
 
 interface Props {
     pid: number;

--- a/frontend/src/ReportDeleteForm.tsx
+++ b/frontend/src/ReportDeleteForm.tsx
@@ -3,12 +3,13 @@ import React from "react";
 import AdminFormLayout from "./AdminFormLayout";
 import useConditionalActionEffect from "./hooks/useConditionalActionEffect";
 import useFormData, { initializeToDefaults } from "./hooks/useFormData";
+import { toErrorMessage } from "./networkErrorHandlers";
 import {
     ProcessedGameReport,
     ReportDeleteFormData,
     ValidReportDeleteFormData,
 } from "./types";
-import { displayTime, toErrorMessage } from "./utils";
+import { displayTime } from "./utils";
 
 interface Props {
     report: ProcessedGameReport;

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -111,6 +111,8 @@ export const playerStates = ["Active", "Inactive"] as const;
 export enum ErrorMessage {
     Default = "Something went wrong. Please contact an admin for assistance.",
     NotAuthorized = "You cannot pass! If you're an administrator, your session may have expired. Please log in and try again.",
+    NotAuthorizedStatus = "You cannot pass!",
+    UnknownAuthStatus = "Sign-in unavailable",
     Required = "Required",
     OnSubmit = "Could not submit, please resolve errors",
     MissingPlayerName = "This player does not exist in the database. Unless it's a new player, please check the spelling.",

--- a/frontend/src/hooks/useFormData.tsx
+++ b/frontend/src/hooks/useFormData.tsx
@@ -7,7 +7,8 @@ import {
     SuccessMessage,
 } from "../types";
 import { ErrorMessage } from "../constants";
-import { isServerError, objectKeys } from "../utils";
+import { isServerError, logNetworkError } from "../networkErrorHandlers";
+import { objectKeys } from "../utils";
 
 type Helpers<F> = {
     setFormData: Dispatch<SetStateAction<ConstrainedFormData<F>>>;
@@ -145,7 +146,7 @@ export default function useFormData<F, V extends F>({
                 setSuccessMessage(successMessageText);
             }
         } catch (error) {
-            console.error("Error submitting form:", error);
+            logNetworkError(error);
             if (isServerError(error)) {
                 setErrorOnSubmit(toErrorMessage(error));
             } else {

--- a/frontend/src/networkErrorHandlers.ts
+++ b/frontend/src/networkErrorHandlers.ts
@@ -12,6 +12,13 @@ export function toErrorMessage(error: ServerErrorBody): string {
     }
 }
 
+export function toAuthStatus(error: unknown): string {
+    if (isServerError(error) && error.status === 401) {
+        return ErrorMessage.NotAuthorizedStatus;
+    }
+    return ErrorMessage.UnknownAuthStatus;
+}
+
 export function logNetworkError(error: unknown) {
     if (isServerError(error)) {
         console.error({

--- a/frontend/src/networkErrorHandlers.ts
+++ b/frontend/src/networkErrorHandlers.ts
@@ -1,0 +1,53 @@
+import { ErrorMessage } from "./constants";
+import { ServerErrorBody } from "./types";
+
+export function toErrorMessage(error: ServerErrorBody): string {
+    switch (error.status) {
+        case 401:
+            return ErrorMessage.NotAuthorized;
+        case 422:
+            return error.response.data;
+        default:
+            return ErrorMessage.Default;
+    }
+}
+
+export function logNetworkError(error: unknown) {
+    if (isServerError(error)) {
+        console.error({
+            responseError: error.response,
+            requestConfig: error.config,
+        });
+    } else if (isRequestError(error)) {
+        console.error({
+            requestError: error.request,
+            requestConfig: error.config,
+        });
+    } else {
+        console.error(error);
+    }
+}
+
+export function isServerError(error: unknown): error is ServerErrorBody {
+    return (
+        isRegularObject(error) &&
+        "status" in error &&
+        "config" in error &&
+        typeof error.status === "number" &&
+        "response" in error &&
+        isRegularObject(error.response) &&
+        "data" in error.response &&
+        typeof error.response.data === "string" &&
+        "headers" in error.response
+    );
+}
+
+function isRequestError(
+    error: unknown
+): error is { request: unknown; config: unknown } {
+    return isRegularObject(error) && "request" in error && "config" in error;
+}
+
+function isRegularObject(obj: unknown): obj is object {
+    return typeof obj === "object" && obj !== null && !Array.isArray(obj);
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -41,8 +41,10 @@ export type UserInfo = {
 export type ServerErrorBody = {
     message: string;
     status: number;
+    config: unknown;
     response: {
         data: string;
+        headers: unknown;
     };
 };
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -34,6 +34,10 @@ export type PlayerState = (typeof playerStates)[number];
 
 export type SuccessMessage = string | null;
 
+export type UserInfo = {
+    isAdmin: boolean;
+};
+
 export type ServerErrorBody = {
     message: string;
     status: number;

--- a/frontend/src/utils.tsx
+++ b/frontend/src/utils.tsx
@@ -1,5 +1,4 @@
-import { ErrorMessage } from "./constants";
-import { Expansion, League, ServerErrorBody, Side, Stronghold } from "./types";
+import { Expansion, League, Side, Stronghold } from "./types";
 
 export function strongholdSide(
     expansions: Expansion[],
@@ -176,31 +175,6 @@ export function isStrongholdInPlay(
         case "MinasMorgul":
         case "Umbar":
             return true;
-    }
-}
-
-export function isServerError(error: unknown): error is ServerErrorBody {
-    return (
-        typeof error === "object" &&
-        error !== null &&
-        "status" in error &&
-        typeof error.status === "number" &&
-        "response" in error &&
-        typeof error.response === "object" &&
-        error.response !== null &&
-        "data" in error.response &&
-        typeof error.response.data === "string"
-    );
-}
-
-export function toErrorMessage(error: ServerErrorBody): string {
-    switch (error.status) {
-        case 401:
-            return ErrorMessage.NotAuthorized;
-        case 422:
-            return error.response.data;
-        default:
-            return ErrorMessage.Default;
     }
 }
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/a9f1c11a-9778-4d99-826d-f79b170938ae)

Expected behavior:
- If you're already signed in, the "signed in" message will be added to the header on mount if a request for your user info succeeds

- Otherwise, a successful sign-in with Google will kick off a new request for your user info, and the "signed in" message will be added to the header after the request succeeds

- If a user info request fails, nothing will be shown in the header

I couldn't do a full local E2E test, but I tested the UI by mocking out the Google button, and making my local server automatically validate auth requests without verification.