### PR TITLE
Add league player API

### DIFF
--- a/backend/src/Api.hs
+++ b/backend/src/Api.hs
@@ -8,7 +8,9 @@ import Servant
     Post,
     PostNoContent,
     QueryParam,
+    QueryParam',
     ReqBody,
+    Required,
     StdMethod (..),
     Verb,
     (:<|>),
@@ -21,6 +23,7 @@ import Types.Api
     GetReportsResponse,
     GoogleLoginResponse,
     IdToken,
+    LeagueStatsResponse,
     ModifyReportRequest,
     RemapPlayerRequest,
     RemapPlayerResponse,
@@ -30,6 +33,9 @@ import Types.Api
     UserInfoResponse,
   )
 import Types.Auth (SessionIdCookie)
+import Types.DataField (League, LeagueTier, PlayerName)
+
+type RequiredQueryParam = QueryParam' '[Required]
 
 type AuthGoogleLoginAPI = "auth" :> "google" :> "login" :> ReqBody '[PlainText] IdToken :> Verb 'POST 204 '[JSON] GoogleLoginResponse
 
@@ -46,6 +52,13 @@ type GetReportsAPI =
 type GetLeaderboardAPI =
   "leaderboard" :> QueryParam "year" Int :> Get '[JSON] GetLeaderboardResponse
 
+type GetLeagueStatsAPI =
+  "leagueStats"
+    :> RequiredQueryParam "league" League
+    :> RequiredQueryParam "tier" LeagueTier
+    :> RequiredQueryParam "year" Int
+    :> Get '[JSON] LeagueStatsResponse
+
 type AdminRenamePlayerAPI =
   "renamePlayer" :> ReqBody '[JSON] RenamePlayerRequest :> PostNoContent
 
@@ -58,11 +71,21 @@ type AdminModifyReportAPI =
 type AdminDeleteReportAPI =
   "deleteReport" :> ReqBody '[JSON] DeleteReportRequest :> PostNoContent
 
+type AdminAddLeaguePlayerAPI =
+  "addLeaguePlayer"
+    :> RequiredQueryParam "league" League
+    :> RequiredQueryParam "tier" LeagueTier
+    :> RequiredQueryParam "year" Int
+    :> QueryParam "playerId" Int64
+    :> QueryParam "playerName" PlayerName
+    :> PostNoContent
+
 type Unprotected =
   AuthGoogleLoginAPI
     :<|> SubmitReportAPI
     :<|> GetReportsAPI
     :<|> GetLeaderboardAPI
+    :<|> GetLeagueStatsAPI
 
 type Protected =
   LogoutAPI
@@ -71,5 +94,6 @@ type Protected =
     :<|> AdminRemapPlayerAPI
     :<|> AdminModifyReportAPI
     :<|> AdminDeleteReportAPI
+    :<|> AdminAddLeaguePlayerAPI
 
 type API = (AuthProtect SessionIdCookie :> Protected) :<|> Unprotected

--- a/backend/src/Database.hs
+++ b/backend/src/Database.hs
@@ -184,16 +184,16 @@ joinedLeagueResults ::
     )
 joinedLeagueResults league tier year =
   table @LeaguePlayer
-    `crossJoin` table @LeaguePlayer
+    `innerJoin` table @LeaguePlayer
+      `on` (\(leaguePlayer :& leagueOpponent) -> isInLeague leaguePlayer &&. isInLeague leagueOpponent)
     `innerJoin` table @Player
       `on` (\(leaguePlayer :& _ :& player) -> leaguePlayer ^. LeaguePlayerPlayerId ==. player ^. PlayerId)
     `innerJoin` table @Player
       `on` (\(_ :& leagueOpponent :& _ :& opponent) -> leagueOpponent ^. LeaguePlayerPlayerId ==. opponent ^. PlayerId)
     `leftJoin` table @GameReport
-      `on` ( \(leaguePlayer :& leagueOpponent :& player :& opponent :& report) ->
+      `on` ( \(_ :& player :& opponent :& report) ->
                isGamePlayedBy report player opponent
-                 &&. isInLeague leaguePlayer
-                 &&. isInLeague leagueOpponent
+                 &&. (report ?. GameReportLeague ==. just (val $ Just league))
                  &&. (report ?. GameReportTimestamp >=. just (val startTime))
                  &&. (report ?. GameReportTimestamp <. just (val endTime))
            )

--- a/backend/src/Database.hs
+++ b/backend/src/Database.hs
@@ -3,7 +3,7 @@ module Database where
 import AppConfig (AppM, Env (..), runAppLogger)
 import Control.Monad.Logger (LoggingT, MonadLogger, logInfoN)
 import Data.Text qualified as T
-import Data.Time (addUTCTime, getCurrentTime, nominalDay)
+import Data.Time (UTCTime (..), addUTCTime, fromGregorian, getCurrentTime, nominalDay)
 import Database.Esqueleto.Experimental
   ( ConnectionPool,
     Entity (..),
@@ -11,19 +11,24 @@ import Database.Esqueleto.Experimental
     PersistStoreWrite (..),
     SqlExpr,
     SqlPersistT,
-    Value (unValue, Value),
+    Value (..),
     asc,
     case_,
+    coalesceDefault,
     countRows,
+    crossJoin,
     delete,
     desc,
     else_,
     from,
     getBy,
+    groupBy,
     innerJoin,
+    isNothing_,
     just,
     leftJoin,
     limit,
+    not_,
     offset,
     on,
     orderBy,
@@ -33,6 +38,7 @@ import Database.Esqueleto.Experimental
     set,
     subSelectCount,
     subSelectUnsafe,
+    sum_,
     table,
     then_,
     update,
@@ -40,6 +46,7 @@ import Database.Esqueleto.Experimental
     val,
     when_,
     where_,
+    (!=.),
     (&&.),
     (+.),
     (/.),
@@ -54,12 +61,15 @@ import Database.Esqueleto.Experimental
   )
 import Servant (ServerError, throwError)
 import Types.Auth (SessionId (..), UserId (..))
-import Types.DataField (PlayerName, Year)
+import Types.DataField (League, LeagueTier, PlayerName, Year)
 import Types.Database
   ( Admin,
     EntityField (..),
     GameReport (..),
     Key (..),
+    LeagueGameStatsRecord,
+    LeagueGameSummaryRecord,
+    LeaguePlayer (..),
     MaybePlayerStats,
     Player (..),
     PlayerId,
@@ -161,6 +171,80 @@ getNumGameReports = do
     pure countRows
   pure $ unValue . fromMaybe (Value 0) $ count
 
+joinedLeagueResults ::
+  League ->
+  LeagueTier ->
+  Year ->
+  From
+    ( SqlExpr (Entity LeaguePlayer)
+        :& SqlExpr (Entity LeaguePlayer)
+        :& SqlExpr (Entity Player)
+        :& SqlExpr (Entity Player)
+        :& SqlExpr (Maybe (Entity GameReport))
+    )
+joinedLeagueResults league tier year =
+  table @LeaguePlayer
+    `crossJoin` table @LeaguePlayer
+    `innerJoin` table @Player
+      `on` (\(leaguePlayer :& _ :& player) -> leaguePlayer ^. LeaguePlayerPlayerId ==. player ^. PlayerId)
+    `innerJoin` table @Player
+      `on` (\(_ :& leagueOpponent :& _ :& opponent) -> leagueOpponent ^. LeaguePlayerPlayerId ==. opponent ^. PlayerId)
+    `leftJoin` table @GameReport
+      `on` ( \(leaguePlayer :& leagueOpponent :& player :& opponent :& report) ->
+               isGamePlayedBy report player opponent
+                 &&. isInLeague leaguePlayer
+                 &&. isInLeague leagueOpponent
+                 &&. (report ?. GameReportTimestamp >=. just (val startTime))
+                 &&. (report ?. GameReportTimestamp <. just (val endTime))
+           )
+  where
+    startTime = UTCTime (fromGregorian (fromIntegral year) 1 1) 0
+    endTime = UTCTime (fromGregorian (fromIntegral year + 1) 1 1) 0
+
+    isInLeague lp =
+      (lp ^. LeaguePlayerLeague ==. val league)
+        &&. lp ^. LeaguePlayerTier ==. val tier
+        &&. lp ^. LeaguePlayerYear ==. val year
+
+    playerWon report player = report ?. GameReportWinnerId ==. just (player ^. PlayerId)
+    playerLost report player = report ?. GameReportLoserId ==. just (player ^. PlayerId)
+
+    isGamePlayedBy report player opponent =
+      (playerWon report player &&. playerLost report opponent) ||. (playerWon report opponent &&. playerLost report player)
+
+getLeaguePlayerSummary :: (MonadIO m, MonadLogger m) => League -> LeagueTier -> Year -> DBAction m [LeagueGameSummaryRecord]
+getLeaguePlayerSummary league tier year = lift . select $ do
+  (_ :& player :& opponent :& report) <- from $ joinedLeagueResults league tier year
+  where_ $ (player ^. PlayerId) !=. (opponent ^. PlayerId) &&. not_ (isNothing_ (report ?. GameReportId))
+  groupBy (player ^. PlayerId)
+  let wins =
+        coalesceDefault
+          [sum_ $ case_ [when_ (playerWon report player) then_ (val (1 :: Int))] (else_ (val 0))]
+          (val 0)
+  pure (player ^. PlayerId, (player ^. PlayerDisplayName, wins, countRows))
+  where
+    playerWon report player = report ?. GameReportWinnerId ==. just (player ^. PlayerId)
+
+getLeagueGameStats :: (MonadIO m, MonadLogger m) => League -> LeagueTier -> Year -> DBAction m [LeagueGameStatsRecord]
+getLeagueGameStats league tier year = lift . select $ do
+  (_ :& player :& opponent :& report) <- from $ joinedLeagueResults league tier year
+  where_ $ (player ^. PlayerId) !=. (opponent ^. PlayerId)
+  groupBy (player ^. PlayerId, opponent ^. PlayerId)
+
+  let wins =
+        coalesceDefault
+          [sum_ $ case_ [when_ (playerWon report player) then_ (val (1 :: Int))] (else_ (val 0))]
+          (val 0)
+
+      losses =
+        coalesceDefault
+          [sum_ $ case_ [when_ (playerWon report opponent) then_ (val (1 :: Int))] (else_ (val 0))]
+          (val 0)
+
+  pure (player ^. PlayerId, (opponent ^. PlayerId, opponent ^. PlayerDisplayName, wins, losses))
+  where
+    playerWon report player = report ?. GameReportWinnerId ==. just (player ^. PlayerId)
+
 insertPlayerIfNotExists :: (MonadIO m, MonadLogger m) => PlayerName -> DBAction m (Entity Player)
 insertPlayerIfNotExists name = do
   player <- getPlayerByName name
@@ -190,6 +274,9 @@ insertLegacyEntry entry = do
 
   insertInitialStats initialStats
   repsertPlayerStats (totalStats, yearStats)
+
+insertLeaguePlayer :: (MonadIO m, MonadLogger m) => LeaguePlayer -> DBAction m ()
+insertLeaguePlayer = lift . insert_
 
 repsertPlayerStats :: (MonadIO m, MonadLogger m) => PlayerStats -> DBAction m ()
 repsertPlayerStats (totalStats@(PlayerStatsTotal {..}), yearStats@(PlayerStatsYear {..})) = lift $ do

--- a/backend/src/Database.hs
+++ b/backend/src/Database.hs
@@ -16,7 +16,6 @@ import Database.Esqueleto.Experimental
     case_,
     coalesceDefault,
     countRows,
-    crossJoin,
     delete,
     desc,
     else_,

--- a/backend/src/Types/DataField.hs
+++ b/backend/src/Types/DataField.hs
@@ -82,7 +82,7 @@ instance ToJSON Competition
 
 instance FromJSON Competition
 
-data League = GeneralLeague | LoMELeague | WoMELeague | SuperLeague | TTSLeague deriving (Eq, Generic, Read, Show)
+data League = GeneralLeague | LoMELeague | WoMELeague | SuperLeague | TTSLeague deriving (Eq, Generic, Ord, Read, Show)
 
 instance PersistField League where
   toPersistValue = defaultToPersistValue
@@ -94,6 +94,19 @@ instance PersistFieldSql League where
 instance ToJSON League
 
 instance FromJSON League
+
+data LeagueTier = Tier1 | Tier2 | Tier3 deriving (Eq, Generic, Ord, Read, Show)
+
+instance PersistField LeagueTier where
+  toPersistValue = defaultToPersistValue
+  fromPersistValue = defaultFromPersistValue
+
+instance PersistFieldSql LeagueTier where
+  sqlType _ = SqlString
+
+instance ToJSON LeagueTier
+
+instance FromJSON LeagueTier
 
 data Expansion = LoME | WoME | KoME | Cities | FateOfErebor | Treebeard deriving (Eq, Generic, Read, Show)
 

--- a/backend/src/Types/Database.hs
+++ b/backend/src/Types/Database.hs
@@ -5,11 +5,11 @@ module Types.Database where
 
 import Control.Monad.Logger (LogLevel (..), ToLogStr (..))
 import Data.Time (UTCTime)
-import Database.Esqueleto.Experimental (Entity, rawExecute, runMigrationQuiet, runSqlPool)
+import Database.Esqueleto.Experimental (Entity, Value, rawExecute, runMigrationQuiet, runSqlPool)
 import Database.Esqueleto.Experimental qualified as SQL
 import Database.Persist.TH (mkMigrate, mkPersist, persistLowerCase, share, sqlSettings)
 import Logging (Logger, log)
-import Types.DataField (Competition, Expansion, League, Match, PlayerName, Rating, Side (..), Stronghold, Victory, Year)
+import Types.DataField (Competition, Expansion, League, LeagueTier, Match, PlayerName, Rating, Side (..), Stronghold, Victory, Year)
 
 share
   [mkPersist sqlSettings, mkMigrate "migrateAdmin"]
@@ -83,6 +83,14 @@ share
     gameCount Int
     Primary playerId
     deriving Show
+
+  LeaguePlayer
+    league League
+    tier LeagueTier
+    year Int
+    playerId PlayerId
+    Primary league tier year playerId
+    deriving Show
 |]
 
 migrateSchema :: SQL.ConnectionPool -> Logger -> IO ()
@@ -105,6 +113,14 @@ type PlayerStats = (PlayerStatsTotal, PlayerStatsYear)
 type MaybePlayerStats = (Maybe (Entity PlayerStatsTotal), Maybe (Entity PlayerStatsYear))
 
 type ReportInsertion = (Entity GameReport, Entity Player, Entity Player)
+
+type LeagueGameSummaryRecord = (Value PlayerId, (Value Text, Value Int, Value Int))
+
+type LeagueGameSummaryMap = Map PlayerId (Text, Int, Int)
+
+type LeagueGameStatsRecord = (Value PlayerId, (Value PlayerId, Value Text, Value Int, Value Int))
+
+type LeagueGameStatsMap = Map PlayerId [(PlayerId, Text, Int, Int)]
 
 toPlayerStatsTotal :: PlayerStatsInitial -> PlayerStatsTotal
 toPlayerStatsTotal (PlayerStatsInitial {..}) =


### PR DESCRIPTION
![](https://media.giphy.com/media/cHNujlGjbNUdJPtRpU/giphy.gif?cid=ecf05e479fw1ceal0m4qiwih4nozytf2bhyhuac5ijxljmwe&ep=v1_gifs_search&rid=giphy.gif&ct=g)

In the interest of managing complexity, this is sort of a partial PR. It adds APIs for adding a new league player, and querying the league stats (FYI I did change some field names, `wins` -> `totalWins` and `gameCount` -> `totalCount`)

TODO:
* The `points` value is not yet calculated, and will come in a follow-up PR
* Migrating existing league players from our CSV data will also come in a follow-up.