### PR TITLE
New league player form

### DIFF
--- a/frontend/src/AdminFormLayout.tsx
+++ b/frontend/src/AdminFormLayout.tsx
@@ -59,20 +59,19 @@ export default function AdminFormLayout({
                         gap={2}
                         sx={{ my: 2, width: "100%" }}
                     >
-                        {children
-                            ? children
-                            : formElementsProps.map(
-                                  ({ element, label, ...props }) => (
-                                      <FormElement
-                                          key={label}
-                                          layoutTheme="minimal"
-                                          label={label}
-                                          {...props}
-                                      >
-                                          {element}
-                                      </FormElement>
-                                  )
-                              )}
+                        {children}
+                        {formElementsProps.map(
+                            ({ element, label, ...props }) => (
+                                <FormElement
+                                    key={label}
+                                    layoutTheme="minimal"
+                                    label={label}
+                                    {...props}
+                                >
+                                    {element}
+                                </FormElement>
+                            )
+                        )}
                     </Box>
 
                     <Button

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -49,6 +49,8 @@ export default function App() {
     const [loadingLeague, setLoadingLeague] = useState(false);
     const [leagueError, setLeagueError] = useState<string | null>(null);
 
+    const playerNames = leaderboard.map((entry) => entry.name);
+
     const getUserInfo = (onError: (error: unknown) => void) => {
         setLoadingUserInfo(true);
         setLoginError(null);
@@ -193,8 +195,8 @@ export default function App() {
                             path="/game-report"
                             element={
                                 <GameReportForm
-                                    leaderboard={leaderboard}
-                                    loadingLeaderboard={loadingLeaderboard}
+                                    playerNames={playerNames}
+                                    loadingPlayers={loadingLeaderboard}
                                 />
                             }
                         />
@@ -202,8 +204,8 @@ export default function App() {
                             path="/game-reports"
                             element={
                                 <GameReports
-                                    leaderboard={leaderboard}
-                                    loadingLeaderboard={loadingLeaderboard}
+                                    playerNames={playerNames}
+                                    loadingPlayers={loadingLeaderboard}
                                     isAdmin={userInfo?.isAdmin || false}
                                 />
                             }
@@ -230,7 +232,9 @@ export default function App() {
                                     params={leagueParams}
                                     setParams={setLeagueParams}
                                     stats={leagueStats}
+                                    playerNames={playerNames}
                                     loading={loadingLeague}
+                                    loadingPlayers={loadingLeaderboard}
                                     error={leagueError}
                                     refresh={getLeagueStats}
                                 />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -235,6 +235,7 @@ export default function App() {
                                     playerNames={playerNames}
                                     loading={loadingLeague}
                                     loadingPlayers={loadingLeaderboard}
+                                    isAdmin={userInfo?.isAdmin || false}
                                     error={leagueError}
                                     refresh={getLeagueStats}
                                 />

--- a/frontend/src/Autocomplete.tsx
+++ b/frontend/src/Autocomplete.tsx
@@ -11,6 +11,7 @@ interface Props<O extends string | PlayerOption> {
     placeholder: string;
     loading: boolean;
     alertText?: string;
+    alertPosition?: "above" | "below";
     onChange?: (value: O | null) => void;
     onInputValueChange?: (value: string) => void;
     validate: () => void;
@@ -22,6 +23,7 @@ export default function Autocomplete<O extends string | PlayerOption>({
     placeholder,
     loading,
     alertText,
+    alertPosition = "above",
     onChange = () => {},
     onInputValueChange = () => {},
     validate,
@@ -30,13 +32,18 @@ export default function Autocomplete<O extends string | PlayerOption>({
     const [displayedAlertText, setDisplayedAlertText] =
         useState<ReactNode>(null);
 
+    const alert = (
+        <Alert
+            color="warning"
+            sx={alertPosition === "above" ? { mb: "10px" } : { mt: "10px" }}
+        >
+            {displayedAlertText}
+        </Alert>
+    );
+
     return (
         <Box>
-            {displayedAlertText && (
-                <Alert color="warning" sx={{ mb: "10px" }}>
-                    {displayedAlertText}
-                </Alert>
-            )}
+            {displayedAlertText && alertPosition === "above" && alert}
 
             <MaterialAutocomplete
                 clearOnEscape
@@ -73,6 +80,8 @@ export default function Autocomplete<O extends string | PlayerOption>({
                     loading ? <CircularProgress size="sm" /> : undefined
                 }
             />
+
+            {displayedAlertText && alertPosition === "below" && alert}
         </Box>
     );
 }

--- a/frontend/src/GameReportForm/index.tsx
+++ b/frontend/src/GameReportForm/index.tsx
@@ -29,7 +29,6 @@ import { toErrorMessage } from "../networkErrorHandlers";
 import {
     GameFormData,
     GameReportPayload,
-    LeaderboardEntry,
     ProcessedGameReport,
     ServerErrorBody,
     ServerValidationError,
@@ -59,20 +58,19 @@ import useGameReportClearEffects from "../hooks/useGameReportFormEffects";
 
 interface Props {
     report?: ProcessedGameReport;
-    leaderboard: LeaderboardEntry[];
-    loadingLeaderboard: boolean;
+    playerNames: string[];
+    loadingPlayers: boolean;
     refreshGameReports?: () => void;
     exit?: () => void;
 }
 
 function GameReportForm({
     report,
-    leaderboard,
-    loadingLeaderboard,
+    playerNames,
+    loadingPlayers,
     refreshGameReports = () => {},
     exit,
 }: Props) {
-    const playerNames = leaderboard.map((entry) => entry.name);
     const initialFormData = getInitialFormData(report, report && playerNames);
     const emptyFormData = getInitialFormData();
 
@@ -173,7 +171,7 @@ function GameReportForm({
                 <Autocomplete
                     options={playerNames}
                     current={formData.winner.value || ""}
-                    loading={loadingLeaderboard}
+                    loading={loadingPlayers}
                     alertText={
                         report
                             ? undefined
@@ -197,7 +195,7 @@ function GameReportForm({
                 <Autocomplete
                     options={playerNames}
                     current={formData.loser.value || ""}
-                    loading={loadingLeaderboard}
+                    loading={loadingPlayers}
                     alertText={
                         report
                             ? undefined

--- a/frontend/src/GameReports.tsx
+++ b/frontend/src/GameReports.tsx
@@ -12,7 +12,6 @@ import { ErrorMessage } from "./constants";
 import {
     Competition,
     Expansion,
-    LeaderboardEntry,
     League,
     Match,
     ProcessedGameReport,
@@ -56,14 +55,14 @@ const PAGE_FOOTER_HEIGHT = 50;
 const PAGE_LIMIT = 100;
 
 interface Props {
-    leaderboard: LeaderboardEntry[];
-    loadingLeaderboard: boolean;
+    playerNames: string[];
+    loadingPlayers: boolean;
     isAdmin: boolean;
 }
 
 export default function GameReports({
-    leaderboard,
-    loadingLeaderboard,
+    playerNames,
+    loadingPlayers,
     isAdmin,
 }: Props) {
     const [reports, setReports] = useState<ProcessedGameReport[]>([]);
@@ -118,8 +117,8 @@ export default function GameReports({
                             <Box overflow="auto" mt={3}>
                                 <GameReportForm
                                     report={reportEditParams}
-                                    leaderboard={leaderboard}
-                                    loadingLeaderboard={loadingLeaderboard}
+                                    playerNames={playerNames}
+                                    loadingPlayers={loadingPlayers}
                                     refreshGameReports={() =>
                                         refresh(currentPage)
                                     }

--- a/frontend/src/LeaguePlayerForm.tsx
+++ b/frontend/src/LeaguePlayerForm.tsx
@@ -1,0 +1,147 @@
+import axios from "axios";
+import React from "react";
+import Box from "@mui/joy/Box";
+import { ErrorMessage } from "./constants";
+import { toErrorMessage } from "./networkErrorHandlers";
+import {
+    League,
+    LeaguePlayerFormData,
+    LeagueTier,
+    ValidLeaguePlayerFormData,
+} from "./types";
+import useConditionalActionEffect from "./hooks/useConditionalActionEffect";
+import useFormData, { initializeToDefaults } from "./hooks/useFormData";
+import { getLeagueLabel, getLeagueTierLabel } from "./utils";
+import Autocomplete from "./Autocomplete";
+import AdminFormLayout from "./AdminFormLayout";
+
+interface Props {
+    league: League;
+    tier: LeagueTier;
+    year: number;
+    playerNames: string[];
+    loadingPlayers: boolean;
+    refresh: () => void;
+}
+
+export default function LeaguePlayerForm({
+    league,
+    tier,
+    year,
+    playerNames,
+    loadingPlayers,
+    refresh,
+}: Props) {
+    const initialFormData: LeaguePlayerFormData = {
+        league: initializeToDefaults(league),
+        tier: initializeToDefaults(tier),
+        year: initializeToDefaults(year),
+        playerName: initializeToDefaults(null),
+    };
+
+    const [
+        formData,
+        { errorOnSubmit, successMessage, submitting },
+        { handleInputChange, validateField, handleSubmit },
+    ] = useFormData<LeaguePlayerFormData, ValidLeaguePlayerFormData>({
+        initialFormData,
+        optionalFields: [],
+        submit,
+        toErrorMessage,
+    });
+
+    useConditionalActionEffect(!!successMessage, refresh);
+
+    return (
+        <AdminFormLayout
+            header="Add League Player"
+            handleSubmit={handleSubmit}
+            submitting={submitting}
+            errorOnSubmit={errorOnSubmit}
+            successMessage={successMessage}
+            shouldHideFormOnSuccess
+            formElementsProps={[
+                {
+                    label: "Player",
+                    error: formData.playerName.error,
+                    element: (
+                        <Autocomplete
+                            options={playerNames}
+                            current={formData.playerName.value || ""}
+                            loading={loadingPlayers}
+                            alertText={
+                                !!formData.playerName.value &&
+                                !playerNames.includes(formData.playerName.value)
+                                    ? ErrorMessage.MissingPlayerName
+                                    : ""
+                            }
+                            alertPosition="below"
+                            placeholder="Player name"
+                            onInputValueChange={handleInputChange("playerName")}
+                            validate={validateField("playerName")}
+                        />
+                    ),
+                },
+            ]}
+        >
+            <AutoPopulatedField
+                label="League:"
+                value={getLeagueLabel(formData.league.value)}
+            />
+
+            {formData.league.value === "GeneralLeague" && (
+                <AutoPopulatedField
+                    label="Tier:"
+                    value={getLeagueTierLabel(formData.tier.value)}
+                />
+            )}
+
+            <AutoPopulatedField label="Year:" value={formData.year.value} />
+        </AdminFormLayout>
+    );
+}
+
+async function submit(validFormData: ValidLeaguePlayerFormData) {
+    return await axios.post(
+        "https://api.waroftheringcommunity.net:8080/addLeaguePlayer",
+        // "http://localhost:8081/addLeaguePlayer",
+        toPayload(validFormData),
+        {
+            headers: { "Content-Type": "application/json" },
+        }
+    );
+}
+
+type LeaguePlayerPayload = {
+    league: League;
+    tier: LeagueTier;
+    year: number;
+    playerId: number | null;
+    playerName: string | null;
+};
+
+function toPayload(formData: ValidLeaguePlayerFormData): LeaguePlayerPayload {
+    return {
+        league: formData.league.value,
+        tier: formData.tier.value,
+        year: formData.year.value,
+        playerId: null,
+        playerName: formData.playerName.value,
+    };
+}
+
+interface AutoPopulatedFieldProps {
+    label: string;
+    value: string | number;
+}
+
+function AutoPopulatedField({ label, value }: AutoPopulatedFieldProps) {
+    return (
+        <Box display="flex" flexDirection="row">
+            {label}
+            <Box ml="5px" fontWeight="bold">
+                {value}
+            </Box>
+        </Box>
+    );
+}

--- a/frontend/src/Leagues.tsx
+++ b/frontend/src/Leagues.tsx
@@ -34,6 +34,7 @@ interface Props {
     playerNames: string[];
     loading: boolean;
     loadingPlayers: boolean;
+    isAdmin: boolean;
     error: string | null;
     refresh: () => void;
 }
@@ -45,6 +46,7 @@ export default function Leagues({
     playerNames,
     loading,
     loadingPlayers,
+    isAdmin,
     error,
     refresh,
 }: Props) {
@@ -141,6 +143,7 @@ export default function Leagues({
                     <LeagueTable
                         stats={stats}
                         loading={loading}
+                        isAdmin={isAdmin}
                         openLeaguePlayerForm={() =>
                             setLeaguePlayerFormOpen(true)
                         }
@@ -154,12 +157,14 @@ export default function Leagues({
 interface LeagueTableProps {
     stats: LeagueStats;
     loading: boolean;
+    isAdmin: boolean;
     openLeaguePlayerForm: () => void;
 }
 
 function LeagueTable({
     stats,
     loading,
+    isAdmin,
     openLeaguePlayerForm,
 }: LeagueTableProps) {
     const entries = Object.entries(stats);
@@ -168,19 +173,23 @@ function LeagueTable({
 
     return (
         <Table
-            cornerHeader={{
-                content: (
-                    <IconButton
-                        size="sm"
-                        disabled={loading}
-                        onClick={openLeaguePlayerForm}
-                        variant="solid"
-                        color="primary"
-                    >
-                        <AddIcon />
-                    </IconButton>
-                ),
-            }}
+            cornerHeader={
+                isAdmin
+                    ? {
+                          content: (
+                              <IconButton
+                                  size="sm"
+                                  disabled={loading}
+                                  onClick={openLeaguePlayerForm}
+                                  variant="solid"
+                                  color="primary"
+                              >
+                                  <AddIcon />
+                              </IconButton>
+                          ),
+                      }
+                    : undefined
+            }
             colHeaders={[
                 ...FIXED_HEADERS.map(
                     (headerLabel): ColHeaderData => ({

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -219,4 +219,20 @@ export type LeagueGameStats = {
     losses: number;
 };
 
+export type LeaguePlayerFormData = {
+    league: FieldData<League>;
+    tier: FieldData<LeagueTier>;
+    year: FieldData<number>;
+    playerName: FieldData<string | null>;
+};
+
+export type ValidLeaguePlayerFormData = {
+    [K in keyof LeaguePlayerFormData]: {
+        [J in keyof LeaguePlayerFormData[K]]: Exclude<
+            LeaguePlayerFormData[K][J],
+            null
+        >;
+    };
+};
+
 export type ValueOf<T> = T[keyof T];

--- a/frontend/src/utils.tsx
+++ b/frontend/src/utils.tsx
@@ -1,4 +1,4 @@
-import { Expansion, League, Side, Stronghold } from "./types";
+import { Expansion, League, LeagueTier, Side, Stronghold } from "./types";
 
 export function strongholdSide(
     expansions: Expansion[],
@@ -106,6 +106,17 @@ export function getLeagueLabel(league: League): string {
             return "Super";
         case "TTSLeague":
             return "TTS";
+    }
+}
+
+export function getLeagueTierLabel(tier: LeagueTier): string {
+    switch (tier) {
+        case "Tier1":
+            return "Elven";
+        case "Tier2":
+            return "Dwarf";
+        case "Tier3":
+            return "Hobbit";
     }
 }
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/df0a55b7-3879-422a-869f-ab60d18def93)

![image](https://github.com/user-attachments/assets/5d00eecf-c5ec-488f-af35-0d73f027cc11)

The field is the same `Autocomplete` that the game report form uses - it will allow an existing or nonexistent player to be selected/entered, but will display a warning to check the spelling for nonexistent players.

Need to add validation for whether player already exists in the league, still.