### PR TITLE
League delete remap

### DIFF
--- a/backend/src/AppServer.hs
+++ b/backend/src/AppServer.hs
@@ -37,6 +37,7 @@ import Database
     runDb,
     updateActiveStatus,
     updateAdminSessionId,
+    updateLeaguePlayer,
     updatePlayerCountry,
     updatePlayerName,
     updateReports,
@@ -403,10 +404,11 @@ adminRemapPlayerHandler RemapPlayerRequest {fromPid, toPid} = runDb $ do
   _ <- readOrError ("Cannot find player " <>: fromPid) $ lift . get $ fromPid
   player <- readOrError ("Cannot find player " <>: toPid) $ lift . get $ toPid
 
-  updateReports fromPid toPid
+  updateCount <- updateReports fromPid toPid
+  updateLeaguePlayer fromPid toPid
   deletePlayer fromPid
   -- Warning: a deleted player that existed in pre-2022 data will be reintroduced via reprocessReports
-  reprocessReports
+  when (updateCount > 0) reprocessReports
 
   pure $ RemapPlayerResponse player.playerDisplayName
 

--- a/backend/src/Database.hs
+++ b/backend/src/Database.hs
@@ -9,7 +9,6 @@ import Database.Esqueleto.Experimental
     Entity (..),
     From,
     PersistStoreWrite (..),
-    PersistUniqueWrite (..),
     SqlExpr,
     SqlPersistT,
     Value (..),

--- a/backend/src/Database.hs
+++ b/backend/src/Database.hs
@@ -9,6 +9,7 @@ import Database.Esqueleto.Experimental
     Entity (..),
     From,
     PersistStoreWrite (..),
+    PersistUniqueWrite (..),
     SqlExpr,
     SqlPersistT,
     Value (..),
@@ -287,9 +288,9 @@ updatePlayerCountry pid country = lift $ do
     set player [PlayerCountry =. val country]
     where_ (player ^. PlayerId ==. val pid)
 
-updateReports :: (MonadIO m, MonadLogger m) => PlayerId -> PlayerId -> DBAction m ()
+updateReports :: (MonadIO m, MonadLogger m) => PlayerId -> PlayerId -> DBAction m Int64
 updateReports fromPid toPid = lift $ do
-  update $ \report -> do
+  updateCount $ \report -> do
     set
       report
       [ GameReportWinnerId
@@ -301,6 +302,22 @@ updateReports fromPid toPid = lift $ do
             [when_ (report ^. GameReportLoserId ==. val fromPid) then_ (val toPid)]
             (else_ (report ^. GameReportLoserId))
       ]
+
+updateLeaguePlayer :: (MonadIO m, MonadLogger m) => PlayerId -> PlayerId -> DBAction m ()
+updateLeaguePlayer fromPid toPid = lift $ do
+  leagues <- select $ do
+    league <- from $ table @LeaguePlayer
+    where_ (league ^. LeaguePlayerPlayerId ==. val fromPid)
+    pure league
+
+  repsertMany $
+    map
+      ( \(Entity _ lp) ->
+          ( LeaguePlayerKey lp.leaguePlayerLeague lp.leaguePlayerTier lp.leaguePlayerYear toPid,
+            lp {leaguePlayerPlayerId = toPid}
+          )
+      )
+      leagues
 
 updateActiveStatus :: (MonadIO m, MonadLogger m) => DBAction m ()
 updateActiveStatus = do

--- a/backend/src/Types/Database.hs
+++ b/backend/src/Types/Database.hs
@@ -111,7 +111,7 @@ share
     league League
     tier LeagueTier
     year Int
-    playerId PlayerId
+    playerId PlayerId OnDeleteCascade
     Primary league tier year playerId
     deriving Generic
     deriving Show


### PR DESCRIPTION
![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExamFmYmt1NXY2dDFvdW1sMXdpMWVmcXZieWU4dmVndjNkdWVmNzhkNSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/UZuAr03kNcTL71bTWj/giphy.gif)

What happened today:

A player in league named `Sepp G` wanted a name change to `SeppG`. Not knowing how to do that properly, an admin added a new player to the league named `SeppG`. We now have both `Sepp G` and `SeppG` in the system.

Ordinarily, this would be fixed with a `remap` operation, remapping `Sepp G` to `SeppG`. But remap wasn't written to work with league data. This changes things so it can.

We must consider the case where the "new" player, the result of the remap, already exists and is present in league (such as the above example). Although it is easy to imagine scenarios where that may not be the case.

As an added bonus, this PR also speeds up reprocessing after remap, if the "from" player didn't actually play any games.