### PR TITLE
Try to clarify rated game reporting

### DIFF
--- a/frontend/src/GameReportForm/index.tsx
+++ b/frontend/src/GameReportForm/index.tsx
@@ -245,13 +245,23 @@ function GameReportForm({
                 <SingleOptionInput
                     values={matchTypes.slice()}
                     current={formData.match.value}
+                    getLabel={(v) => {
+                        switch (v) {
+                            case "Rated":
+                                return "Rated";
+                            case "Unrated":
+                                return "Unrated (Friendly)";
+                        }
+                    }}
                     onChange={handleInputChange("match")}
                     validate={validateField("match")}
                 />
             </FormElement>
             {formData.match.value === "Rated" && (
                 <FormElement
-                    label={"Was this for a specific competition?"}
+                    label={
+                        "Optional: Was this for a specific competition? If not, leave this blank."
+                    }
                     error={formData.competition.error}
                     hasSingleControl={false}
                     layoutTheme={layoutTheme}


### PR DESCRIPTION
![](https://media.giphy.com/media/IPbS5R4fSUl5S/giphy.gif?cid=790b7611i3febw0826hr0djxpiynbhcl9fchzk23a8tvz27i&ep=v1_gifs_search&rid=giphy.gif&ct=g)

Try to address #220 

Open to other thoughts here. See conversation: https://discord.com/channels/590789678890745857/818775910748258326/1340112563207405599

Having a perma-filled-in dummy value of "Ladder" next to the League/Tournament options might be a nicer way to illustrate this, rather than the additional text?

![image](https://github.com/user-attachments/assets/00872d53-4229-4f53-b5e7-5a39fc5ccdd9)
