### PR TITLE
Add player filters to game reports page

### DIFF
--- a/backend/src/Api.hs
+++ b/backend/src/Api.hs
@@ -24,6 +24,7 @@ import Types.Api
   ( DeleteReportRequest,
     EditPlayerRequest,
     ExportResponse,
+    GameReportFilterSpec,
     GetLeaderboardResponse,
     GetReportsResponse,
     GoogleLoginResponse,
@@ -51,7 +52,11 @@ type SubmitReportAPI =
   "submitReport" :> MultipartForm Tmp SubmitReportRequest :> Post '[JSON] SubmitGameReportResponse
 
 type GetReportsAPI =
-  "reports" :> QueryParam "limit" Int64 :> QueryParam "offset" Int64 :> Get '[JSON] GetReportsResponse
+  "reports"
+    :> QueryParam "limit" Int64
+    :> QueryParam "offset" Int64
+    :> QueryParam "filter" GameReportFilterSpec
+    :> Get '[JSON] GetReportsResponse
 
 type GetLeaderboardAPI =
   "leaderboard" :> QueryParam "year" Int :> Get '[JSON] GetLeaderboardResponse

--- a/backend/src/AppServer.hs
+++ b/backend/src/AppServer.hs
@@ -67,6 +67,7 @@ import Types.Api
   ( DeleteReportRequest (..),
     EditPlayerRequest (..),
     ExportResponse,
+    GameReportFilterSpec,
     GetLeaderboardResponse (GetLeaderboardResponse),
     GetReportsResponse (..),
     GoogleLoginResponse,
@@ -294,10 +295,10 @@ submitReportHandler (SubmitReportRequest rawReport logFileData) = do
       mapM_ (putS3Object awsEnv key . fdPayload) logFileData
       pure SubmitGameReportResponse {report = processedReport, winnerRating, loserRating}
 
-getReportsHandler :: Maybe Int64 -> Maybe Int64 -> AppM GetReportsResponse
-getReportsHandler limit offset =
+getReportsHandler :: Maybe Int64 -> Maybe Int64 -> Maybe GameReportFilterSpec -> AppM GetReportsResponse
+getReportsHandler limit offset filterSpec =
   runDb getNumGameReports >>= \total ->
-    runDb (getGameReports limit' offset') >>= \reports ->
+    runDb (getGameReports limit' offset' filterSpec) >>= \reports ->
       pure GetReportsResponse {reports = fromGameReport <$> reports, total}
   where
     maxLimit = 500

--- a/backend/src/AppServer.hs
+++ b/backend/src/AppServer.hs
@@ -297,7 +297,7 @@ submitReportHandler (SubmitReportRequest rawReport logFileData) = do
 
 getReportsHandler :: Maybe Int64 -> Maybe Int64 -> Maybe GameReportFilterSpec -> AppM GetReportsResponse
 getReportsHandler limit offset filterSpec =
-  runDb getNumGameReports >>= \total ->
+  runDb (getNumGameReports filterSpec) >>= \total ->
     runDb (getGameReports limit' offset' filterSpec) >>= \reports ->
       pure GetReportsResponse {reports = fromGameReport <$> reports, total}
   where

--- a/backend/src/Database.hs
+++ b/backend/src/Database.hs
@@ -115,7 +115,7 @@ toFilterExpression winner loser report spec = foldr ((&&.) . fromMaybe (val True
   where
     toFilter entity field values = ((entity ^. field) `in_`) . valList <$> values
     filterList = [playerFilter, winnerFilter, loserFilter, leagueFilter]
-    playerFilter = (toFilter winner PlayerName spec.players) ||. (toFilter loser PlayerName spec.players)
+    playerFilter = liftA2 (||.) (toFilter winner PlayerName spec.players) (toFilter loser PlayerName spec.players)
     winnerFilter = toFilter winner PlayerName spec.winners
     loserFilter = toFilter loser PlayerName spec.losers
     leagueFilter = toFilter report GameReportLeague (map Just <$> spec.leagues)

--- a/backend/src/Database.hs
+++ b/backend/src/Database.hs
@@ -171,9 +171,7 @@ getGameReports limit' offset' filterSpec = lift . select $ do
   orderBy [desc (report ^. GameReportTimestamp)]
   limit limit'
   offset offset'
-  case filterSpec of
-    Nothing -> pass
-    Just spec -> where_ $ toFilterExpression report spec
+  for_ filterSpec (where_ . toFilterExpression report)
   pure (report, winner, loser)
 
 getAllGameReports :: (MonadIO m, MonadLogger m) => SortOrder -> DBAction m [(Entity GameReport, Entity Player, Entity Player)]
@@ -191,7 +189,6 @@ getNumGameReports filterSpec = do
     report <- from $ table @GameReport
     for_ filterSpec (where_ . toFilterExpression report)
     pure countRows
-
   pure $ unValue . fromMaybe (Value 0) $ count
 
 joinedLeagueResults ::

--- a/backend/src/Database.hs
+++ b/backend/src/Database.hs
@@ -189,10 +189,9 @@ getNumGameReports :: (MonadIO m, MonadLogger m) => Maybe GameReportFilterSpec ->
 getNumGameReports filterSpec = do
   count <- lift . selectOne $ do
     report <- from $ table @GameReport
-    case filterSpec of
-      Nothing -> pass
-      Just spec -> where_ $ toFilterExpression report spec
+    for_ filterSpec (where_ . toFilterExpression report)
     pure countRows
+
   pure $ unValue . fromMaybe (Value 0) $ count
 
 joinedLeagueResults ::

--- a/backend/src/Database.hs
+++ b/backend/src/Database.hs
@@ -114,7 +114,8 @@ toFilterExpression ::
 toFilterExpression winner loser report spec = foldr ((&&.) . fromMaybe (val True)) (val True) filterList
   where
     toFilter entity field values = ((entity ^. field) `in_`) . valList <$> values
-    filterList = [winnerFilter, loserFilter, leagueFilter]
+    filterList = [playerFilter, winnerFilter, loserFilter, leagueFilter]
+    playerFilter = (toFilter winner PlayerName spec.players) ||. (toFilter loser PlayerName spec.players)
     winnerFilter = toFilter winner PlayerName spec.winners
     loserFilter = toFilter loser PlayerName spec.losers
     leagueFilter = toFilter report GameReportLeague (map Just <$> spec.leagues)

--- a/backend/src/Types/Api.hs
+++ b/backend/src/Types/Api.hs
@@ -308,9 +308,9 @@ fromLeagueGameStatsMap playerId =
 type ExportResponse = (Headers '[Header "Content-Disposition" String]) (SourceIO StrictByteString)
 
 data GameReportFilterSpec = GameReportFilterSpec
-  { players :: Maybe [PlayerName],
-    winners :: Maybe [PlayerName],
-    losers :: Maybe [PlayerName],
+  { players :: Maybe [PlayerId],
+    winners :: Maybe [PlayerId],
+    losers :: Maybe [PlayerId],
     leagues :: Maybe [League]
   }
   deriving (Generic)

--- a/backend/src/Types/Api.hs
+++ b/backend/src/Types/Api.hs
@@ -309,6 +309,7 @@ type ExportResponse = (Headers '[Header "Content-Disposition" String]) (SourceIO
 
 data GameReportFilterSpec = GameReportFilterSpec
   { players :: Maybe [PlayerId],
+    pairing :: Maybe (PlayerId, Maybe PlayerId),
     winners :: Maybe [PlayerId],
     losers :: Maybe [PlayerId],
     leagues :: Maybe [League]

--- a/backend/src/Types/Api.hs
+++ b/backend/src/Types/Api.hs
@@ -308,7 +308,8 @@ fromLeagueGameStatsMap playerId =
 type ExportResponse = (Headers '[Header "Content-Disposition" String]) (SourceIO StrictByteString)
 
 data GameReportFilterSpec = GameReportFilterSpec
-  { winners :: Maybe [PlayerName],
+  { players :: Maybe [PlayerName],
+    winners :: Maybe [PlayerName],
     losers :: Maybe [PlayerName],
     leagues :: Maybe [League]
   }

--- a/backend/src/Types/Api.hs
+++ b/backend/src/Types/Api.hs
@@ -1,11 +1,11 @@
 module Types.Api where
 
-import Data.Aeson (FromJSON, ToJSON, eitherDecodeStrict)
+import Data.Aeson (FromJSON, ToJSON, eitherDecodeStrict, eitherDecodeStrictText)
 import Data.ByteString (StrictByteString)
 import Data.Time (UTCTime)
 import Database.Esqueleto.Experimental (Entity (..))
 import Relude.Extra (lookupDefault)
-import Servant (Header, Headers, MimeUnrender (..), NoContent, PlainText, SourceIO)
+import Servant (FromHttpApiData (..), Header, Headers, MimeUnrender (..), NoContent, PlainText, SourceIO)
 import Servant.Multipart (FileData (..), FromMultipart (..), MultipartData (..), Tmp, lookupFile, lookupInput)
 import Types.DataField (Competition, Expansion, League, Match, PlayerName, Rating, Side, Stronghold, Victory)
 import Types.Database
@@ -306,3 +306,16 @@ fromLeagueGameStatsMap playerId =
   fromList . fmap (\(opponentId, opponent, wins, losses) -> (opponentId, LeagueGameStats {..})) . lookupDefault [] playerId
 
 type ExportResponse = (Headers '[Header "Content-Disposition" String]) (SourceIO StrictByteString)
+
+data GameReportFilterSpec = GameReportFilterSpec
+  { winners :: Maybe [PlayerName],
+    losers :: Maybe [PlayerName],
+    leagues :: Maybe [League]
+  }
+  deriving (Generic)
+
+instance FromJSON GameReportFilterSpec
+
+instance FromHttpApiData GameReportFilterSpec where
+  parseQueryParam :: Text -> Either Text GameReportFilterSpec
+  parseQueryParam = first toText . eitherDecodeStrictText

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -52,7 +52,9 @@ export default function App() {
 
     const [exporting, setExporting] = useState(false);
 
-    const playerNames = leaderboard.map((entry) => entry.name);
+    const playerNames = leaderboard
+        .map((entry) => entry.name)
+        .sort((a, b) => a.localeCompare(b));
 
     const getUserInfo = (onError: (error: unknown) => void) => {
         setLoadingUserInfo(true);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -21,7 +21,13 @@ import { BrowserRouter, Routes, Route, Link } from "react-router-dom";
 import { ErrorMessage } from "./constants";
 import { logNetworkError } from "./networkErrorHandlers";
 import { HEADER_HEIGHT_PX, HEADER_MARGIN_PX } from "./styles/sizes";
-import { LeaderboardEntry, LeagueParams, LeagueStats, UserInfo } from "./types";
+import {
+    LeaderboardEntry,
+    LeagueParams,
+    LeagueStats,
+    MenuOption,
+    UserInfo,
+} from "./types";
 import { API_BASE_URL } from "./env";
 import { GoogleOAuthProvider } from "@react-oauth/google";
 import GoogleLoginButton from "./GoogleLogin";
@@ -52,9 +58,11 @@ export default function App() {
 
     const [exporting, setExporting] = useState(false);
 
-    const playerNames = leaderboard
-        .map((entry) => entry.name)
-        .sort((a, b) => a.localeCompare(b));
+    const playerOptions = leaderboard
+        .map((entry): MenuOption => ({ label: entry.name, id: entry.pid }))
+        .sort((a, b) => a.label.localeCompare(b.label));
+
+    const playerNames = playerOptions.map(({ label }) => label);
 
     const getUserInfo = (onError: (error: unknown) => void) => {
         setLoadingUserInfo(true);
@@ -206,7 +214,7 @@ export default function App() {
                             path="/game-reports"
                             element={
                                 <GameReports
-                                    playerNames={playerNames}
+                                    playerOptions={playerOptions}
                                     loadingPlayers={loadingLeaderboard}
                                     isAdmin={userInfo?.isAdmin || false}
                                 />

--- a/frontend/src/GameReports.tsx
+++ b/frontend/src/GameReports.tsx
@@ -94,18 +94,9 @@ export default function GameReports({
                     limit: PAGE_LIMIT,
                     offset: getReportsOffset(page),
                     filter: JSON.stringify({
-                        winners: nullifyEmpty(
-                            mergePlayerFilters(
-                                filters.winners,
-                                filters.players
-                            ).map(normalizeName)
-                        ),
-                        losers: nullifyEmpty(
-                            mergePlayerFilters(
-                                filters.losers,
-                                filters.players
-                            ).map(normalizeName)
-                        ),
+                        winners: toPlayerFilterParam(filters.winners),
+                        losers: toPlayerFilterParam(filters.losers),
+                        players: toPlayerFilterParam(filters.players),
                     }),
                 },
             });
@@ -694,22 +685,14 @@ function countVictoryPoints(
         .reduce((sum, points) => sum + points, 0);
 }
 
-function mergePlayerFilters(filterA: string[], filterB: string[]) {
-    return filterA.length && filterB.length
-        ? intersection(filterA, filterB)
-        : filterA.length
-        ? filterA
-        : filterB;
+function toPlayerFilterParam(names: string[]) {
+    return nullifyEmpty(names.map(normalizeName));
 }
 
 function normalizeName(name: string) {
     return name.toLowerCase().trim();
 }
 
-function nullifyEmpty(arr: unknown[]) {
+function nullifyEmpty<T>(arr: T[]) {
     return arr.length ? arr : null;
-}
-
-function intersection<T>(arrayA: T[], arrayB: T[]) {
-    return arrayA.filter((v) => arrayB.includes(v));
 }

--- a/frontend/src/GameReports.tsx
+++ b/frontend/src/GameReports.tsx
@@ -19,6 +19,7 @@ import {
     GameReportFilters,
     League,
     Match,
+    MenuOption,
     ProcessedGameReport,
     ReportEditMode,
     Side,
@@ -63,13 +64,13 @@ const PLAYER_COL_WIDTH = 130;
 const PAGE_LIMIT = 100;
 
 interface Props {
-    playerNames: string[];
+    playerOptions: MenuOption[];
     loadingPlayers: boolean;
     isAdmin: boolean;
 }
 
 export default function GameReports({
-    playerNames,
+    playerOptions,
     loadingPlayers,
     isAdmin,
 }: Props) {
@@ -132,7 +133,9 @@ export default function GameReports({
                             <Box overflow="auto" mt={3}>
                                 <GameReportForm
                                     report={reportEditParams}
-                                    playerNames={playerNames}
+                                    playerNames={playerOptions.map(
+                                        ({ label }) => label
+                                    )}
                                     loadingPlayers={loadingPlayers}
                                     refreshGameReports={() =>
                                         refresh(currentPage, filters)
@@ -190,7 +193,7 @@ export default function GameReports({
                                 <TableFilter
                                     placeholder="Select players"
                                     loading={loadingPlayers}
-                                    options={playerNames}
+                                    options={playerOptions}
                                     width={PAIRING_COL_WIDTH}
                                     current={filters.players}
                                     onChange={(values) =>
@@ -207,7 +210,7 @@ export default function GameReports({
                                 <TableFilter
                                     placeholder="Select winner"
                                     loading={loadingPlayers}
-                                    options={playerNames}
+                                    options={playerOptions}
                                     width={PLAYER_COL_WIDTH}
                                     current={filters.winners}
                                     onChange={(values) =>
@@ -221,7 +224,7 @@ export default function GameReports({
                                 <TableFilter
                                     placeholder="Select loser"
                                     loading={loadingPlayers}
-                                    options={playerNames}
+                                    options={playerOptions}
                                     width={PLAYER_COL_WIDTH}
                                     current={filters.losers}
                                     onChange={(values) =>
@@ -685,12 +688,8 @@ function countVictoryPoints(
         .reduce((sum, points) => sum + points, 0);
 }
 
-function toPlayerFilterParam(names: string[]) {
-    return nullifyEmpty(names.map(normalizeName));
-}
-
-function normalizeName(name: string) {
-    return name.toLowerCase().trim();
+function toPlayerFilterParam(playerOptions: MenuOption[]): number[] | null {
+    return nullifyEmpty(playerOptions.map(({ id }) => id));
 }
 
 function nullifyEmpty<T>(arr: T[]) {

--- a/frontend/src/GameReports.tsx
+++ b/frontend/src/GameReports.tsx
@@ -93,7 +93,7 @@ export default function GameReports({
                 params: {
                     limit: PAGE_LIMIT,
                     offset: getReportsOffset(page),
-                    filter: {
+                    filter: JSON.stringify({
                         winners: nullifyEmpty(
                             mergePlayerFilters(
                                 filters.winners,
@@ -106,7 +106,7 @@ export default function GameReports({
                                 filters.players
                             ).map(normalizeName)
                         ),
-                    },
+                    }),
                 },
             });
             setReports(response.data.reports);

--- a/frontend/src/TableFilter.tsx
+++ b/frontend/src/TableFilter.tsx
@@ -1,0 +1,72 @@
+import React, { useState } from "react";
+import MaterialAutocomplete from "@mui/joy/Autocomplete";
+import Box from "@mui/joy/Box";
+import { MenuOption } from "./types";
+
+interface Props<O extends string | MenuOption> {
+    options: O[];
+    current: O[];
+    placeholder: string;
+    loading: boolean;
+    width: number;
+    onChange: (value: O[]) => void;
+}
+
+export default function TableFilter<O extends string | MenuOption>({
+    options,
+    current,
+    placeholder,
+    loading,
+    width,
+    onChange,
+}: Props<O>) {
+    const [isFocused, setIsFocused] = useState(false);
+
+    return (
+        <th style={{ overflow: "visible" }}>
+            <Box
+                sx={{
+                    position: "relative",
+                    display: "flex",
+                    justifyContent: "center",
+                    width: `${width}px`,
+                    height: "2em",
+                }}
+            >
+                <MaterialAutocomplete
+                    multiple
+                    clearOnBlur
+                    disableCloseOnSelect
+                    openOnFocus
+                    size="sm"
+                    limitTags={0}
+                    placeholder={placeholder}
+                    options={options}
+                    value={current}
+                    loading={loading}
+                    onFocus={() => setIsFocused(true)}
+                    onBlur={() => setIsFocused(false)}
+                    onChange={(_, values) => onChange(values)}
+                    sx={{
+                        background: "white",
+                        fontSize: "inherit",
+                        minWidth: 0,
+                        lineHeight: 0,
+                        button: { minHeight: 0, height: "100%" },
+                        ...(isFocused
+                            ? {
+                                  position: "absolute",
+                                  width: `${width}px`,
+                                  minHeight: "100%",
+                              }
+                            : {
+                                  minHeight: 0,
+                                  height: "100%",
+                                  maxHeight: "100%",
+                              }),
+                    }}
+                />
+            </Box>
+        </th>
+    );
+}

--- a/frontend/src/TableFilter.tsx
+++ b/frontend/src/TableFilter.tsx
@@ -1,6 +1,9 @@
 import React, { useState } from "react";
 import MaterialAutocomplete from "@mui/joy/Autocomplete";
 import Box from "@mui/joy/Box";
+import FormControl from "@mui/joy/FormControl";
+import FormHelperText from "@mui/joy/FormHelperText";
+import { ErrorMessage } from "./constants";
 import { MenuOption } from "./types";
 
 interface Props<O extends string | MenuOption> {
@@ -9,6 +12,7 @@ interface Props<O extends string | MenuOption> {
     placeholder: string;
     loading: boolean;
     width: number;
+    errorMessage?: ErrorMessage;
     onChange: (value: O[]) => void;
 }
 
@@ -18,55 +22,64 @@ export default function TableFilter<O extends string | MenuOption>({
     placeholder,
     loading,
     width,
+    errorMessage,
     onChange,
 }: Props<O>) {
     const [isFocused, setIsFocused] = useState(false);
 
     return (
         <th style={{ overflow: "visible" }}>
-            <Box
-                sx={{
-                    position: "relative",
-                    display: "flex",
-                    justifyContent: "center",
-                    width: `${width}px`,
-                    height: "2em",
-                }}
-            >
-                <MaterialAutocomplete
-                    multiple
-                    clearOnBlur
-                    disableCloseOnSelect
-                    openOnFocus
-                    size="sm"
-                    limitTags={0}
-                    placeholder={placeholder}
-                    options={options}
-                    value={current}
-                    loading={loading}
-                    onFocus={() => setIsFocused(true)}
-                    onBlur={() => setIsFocused(false)}
-                    onChange={(_, values) => onChange(values)}
+            <FormControl error={!!errorMessage}>
+                {errorMessage && (
+                    <FormHelperText sx={{ mb: "3px", fontSize: "inherit" }}>
+                        {errorMessage}
+                    </FormHelperText>
+                )}
+
+                <Box
                     sx={{
-                        background: "white",
-                        fontSize: "inherit",
-                        minWidth: 0,
-                        lineHeight: 0,
-                        button: { minHeight: 0, height: "100%" },
-                        ...(isFocused
-                            ? {
-                                  position: "absolute",
-                                  width: `${width}px`,
-                                  minHeight: "100%",
-                              }
-                            : {
-                                  minHeight: 0,
-                                  height: "100%",
-                                  maxHeight: "100%",
-                              }),
+                        position: "relative",
+                        display: "flex",
+                        justifyContent: "center",
+                        width: `${width}px`,
+                        height: "2em",
                     }}
-                />
-            </Box>
+                >
+                    <MaterialAutocomplete
+                        multiple
+                        clearOnBlur
+                        disableCloseOnSelect
+                        openOnFocus
+                        size="sm"
+                        limitTags={0}
+                        placeholder={placeholder}
+                        options={options}
+                        value={current}
+                        loading={loading}
+                        onFocus={() => setIsFocused(true)}
+                        onBlur={() => setIsFocused(false)}
+                        onChange={(_, values) => onChange(values)}
+                        sx={{
+                            background: "white",
+                            fontSize: "inherit",
+                            minWidth: 0,
+                            lineHeight: 0,
+                            button: { minHeight: 0, height: "100%" },
+                            ...(isFocused
+                                ? {
+                                      position: "absolute",
+                                      width: `${width}px`,
+                                      minHeight: "100%",
+                                  }
+                                : {
+                                      minHeight: 0,
+                                      height: "100%",
+                                      maxHeight: "100%",
+                                  }),
+                        }}
+                    />
+                </Box>
+            </FormControl>
         </th>
     );
 }

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -122,6 +122,7 @@ export enum ErrorMessage {
     OnSubmit = "Could not submit, please resolve errors",
     MissingPlayerName = "This player does not exist in the database. Unless it's a new player, please check the spelling.",
     ExistingPlayerRequired = "Must choose an existing player",
+    PairingFilterInvalid = "Select up to two",
 }
 
 export const INFINITE = 100;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -242,3 +242,9 @@ export type ValidLeaguePlayerFormData = {
 };
 
 export type ValueOf<T> = T[keyof T];
+
+export type GameReportFilters = {
+    players: string[];
+    winners: string[];
+    losers: string[];
+};

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -244,7 +244,7 @@ export type ValidLeaguePlayerFormData = {
 export type ValueOf<T> = T[keyof T];
 
 export type GameReportFilters = {
-    players: string[];
-    winners: string[];
-    losers: string[];
+    players: MenuOption[];
+    winners: MenuOption[];
+    losers: MenuOption[];
 };

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -244,6 +244,7 @@ export type ValidLeaguePlayerFormData = {
 export type ValueOf<T> = T[keyof T];
 
 export type GameReportFilters = {
+    pairing: MenuOption[];
     players: MenuOption[];
     winners: MenuOption[];
     losers: MenuOption[];


### PR DESCRIPTION
Started with just winner, loser, and pairing filters! The league filter needs to go with either a new column or custom handling of mixed fields in the `Competition Type` column, and figured whatever change I make there doesn't need to hold up player filtering.

I want to reuse all this UI work for the leaderboard and league tables, but since I have a tables refactor coming up, I didn't worry about it yet - kept most of the work inside the `GameReports` file for now.

<img width="895" alt="image" src="https://github.com/user-attachments/assets/78170699-81c5-4c3f-baac-eb3629449148" />

<img width="893" alt="image" src="https://github.com/user-attachments/assets/dcfa7170-d765-47e4-b088-9e6cd138a11f" />

<img width="888" alt="image" src="https://github.com/user-attachments/assets/10002d7b-5897-4e5c-9998-ba4149ec60b9" />

<img width="893" alt="image" src="https://github.com/user-attachments/assets/d61fa20f-bba7-4b7c-bb42-c46e2aac039f" />

<img width="881" alt="image" src="https://github.com/user-attachments/assets/b9e29272-e33e-4c36-962e-6229072cf8ce" />

<img width="891" alt="image" src="https://github.com/user-attachments/assets/11e1fa39-eb7d-402d-8c7f-5e39e3dee248" />