### PR TITLE
Sort leaderboard by active first

### DIFF
--- a/backend/src/AppServer.hs
+++ b/backend/src/AppServer.hs
@@ -312,7 +312,7 @@ getLeaderboardHandler year = do
   let year' = fromMaybe currentYear year
   runDb (getAllStats year')
     <&> ( GetLeaderboardResponse
-            . sortOn (Down . averageRating)
+            . sortOn (Down . liftA2 (,) isActive averageRating)
             . map (fromPlayerStats . (\(player, stats) -> (player, readStats (entityKey player) year' stats)))
         )
 


### PR DESCRIPTION
![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExdHI4c29ya3J1M3RtbjJ1NGIyd2JhNWwxOWhvaGhqb29rd2FsdHNscyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/Rl9Yqavfj2Ula/giphy.gif)

Resolves #226 

I shadow deployed this - I'm sorry!! But it was pretty trivial. You can now see that the highest rated, inactive player (PeterM) ranks below the lowest rated active player (TMAvenger).

(Promise to set up proper dev stuff soon!!)