### PR TITLE
Dev mode

### DIFF
--- a/backend/.vscode/settings.json
+++ b/backend/.vscode/settings.json
@@ -6,6 +6,7 @@
         "Angmar",
         "aragorn",
         "arwen",
+        "Baggins",
         "Barad",
         "bimap",
         "certbot",

--- a/backend/app/Server.hs
+++ b/backend/app/Server.hs
@@ -29,29 +29,19 @@ data AppMode = Dev | Prod
 corsMiddleware :: AppMode -> Middleware
 corsMiddleware mode = cors $ const $ Just policy
   where
-    policy = case mode of
-      Dev -> devPolicy
-      Prod -> prodPolicy
-
-    devPolicy =
+    origins = case mode of
+      Dev -> ["http://localhost:3000"]
+      Prod -> ["https://waroftheringcommunity.net"]
+    maxAge = case mode of
+      Dev -> Nothing
+      Prod -> Nothing -- TODO Set to 3600 or 7200 prior to launch
+    policy =
       CorsResourcePolicy
-        { corsOrigins = Just (["http://localhost:3000"], True),
+        { corsOrigins = Just (origins, True),
           corsMethods = [],
           corsRequestHeaders = ["Content-Type"],
           corsExposedHeaders = Just ["Content-Disposition"],
-          corsMaxAge = Nothing,
-          corsVaryOrigin = False,
-          corsRequireOrigin = True,
-          corsIgnoreFailures = False
-        }
-
-    prodPolicy =
-      CorsResourcePolicy
-        { corsOrigins = Just (["https://waroftheringcommunity.net"], True),
-          corsMethods = [],
-          corsRequestHeaders = ["Content-Type"],
-          corsExposedHeaders = Just ["Content-Disposition"],
-          corsMaxAge = Nothing, -- TODO Set to 3600 or 7200 prior to launch
+          corsMaxAge = maxAge,
           corsVaryOrigin = False,
           corsRequireOrigin = True,
           corsIgnoreFailures = False

--- a/backend/app/Server.hs
+++ b/backend/app/Server.hs
@@ -4,7 +4,7 @@ import Amazonka qualified as AWS
 import Api (API)
 import AppConfig (Env (..), authDatabaseFile, databaseFile, logFile, maxGameLogSizeMB, nt, redisConfig, runAppLogger)
 import AppServer (server)
-import Auth (authHandler)
+import Auth (authHandlerDev, authHandlerProd)
 import Control.Monad.Logger (LogLevel (..))
 import Database.Esqueleto.Experimental (defaultConnectionPoolConfig)
 import Database.Persist.Sqlite (createSqlitePoolWithConfig)
@@ -61,7 +61,7 @@ multipartOpts =
 app :: AppMode -> Env -> Application
 app mode env = gzipMiddleware . corsMiddleware mode $ serveWithContextT (Proxy :: Proxy API) context (nt env) server
   where
-    context = authHandler env :. multipartOpts :. EmptyContext
+    context = (\case Dev -> authHandlerDev; Prod -> authHandlerProd) mode env :. multipartOpts :. EmptyContext
 
 runDev :: Env -> Settings -> IO ()
 runDev env settings = runSettings settings . app Dev $ env

--- a/backend/src/Auth.hs
+++ b/backend/src/Auth.hs
@@ -71,8 +71,8 @@ validateToken (JwkSet keys) (IdToken token) = do
       | claims.email_verified && isJust claims.hd = Right ()
       | otherwise = Left GoogleNotAuthoritativeError
 
-authHandler :: Env -> AuthHandler Request Authenticated
-authHandler env = mkAuthHandler (nt env . handler)
+authHandlerProd :: Env -> AuthHandler Request Authenticated
+authHandlerProd env = mkAuthHandler (nt env . handler)
   where
     handler :: Request -> AppM Authenticated
     handler req = do
@@ -86,3 +86,9 @@ authHandler env = mkAuthHandler (nt env . handler)
                 Nothing -> throwError err401 {errBody = "Invalid session."}
                 Just (Entity _ admin) ->
                   pure $ Authenticated {userId = UserId admin.adminUserId, sessionId = SessionId sessionId}
+
+authHandlerDev :: Env -> AuthHandler Request Authenticated
+authHandlerDev env = mkAuthHandler (nt env . handler)
+  where
+    handler :: Request -> AppM Authenticated
+    handler _ = pure Authenticated {userId = UserId "Frodo", sessionId = SessionId "Baggins"}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,7 +4,7 @@
     "description": "War of the Ring community management website.",
     "main": "index.js",
     "scripts": {
-        "start": "webpack serve --port 3000",
+        "start": "NODE_ENV=development webpack serve --port 3000",
         "build": "NODE_ENV=production webpack",
         "test": "echo \"Error: no test specified\" && exit 1"
     },

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -22,6 +22,7 @@ import { ErrorMessage } from "./constants";
 import { logNetworkError } from "./networkErrorHandlers";
 import { HEADER_HEIGHT_PX, HEADER_MARGIN_PX } from "./styles/sizes";
 import { LeaderboardEntry, LeagueParams, LeagueStats, UserInfo } from "./types";
+import { API_BASE_URL } from "./env";
 import { GoogleOAuthProvider } from "@react-oauth/google";
 import GoogleLoginButton from "./GoogleLogin";
 import Leagues from "./Leagues";
@@ -57,8 +58,7 @@ export default function App() {
         setLoadingUserInfo(true);
         setLoginError(null);
         axios
-            // .get("http://localhost:8081/userInfo")
-            .get("https://api.waroftheringcommunity.net:8080/userInfo")
+            .get(`${API_BASE_URL}/userInfo`)
             .then((response) => setUserInfo(response.data))
             .catch(onError)
             .finally(() => setLoadingUserInfo(false));
@@ -68,8 +68,7 @@ export default function App() {
         setLoadingLeaderboard(true);
 
         axios
-            // .get("http://localhost:8081/leaderboard", {
-            .get("https://api.waroftheringcommunity.net:8080/leaderboard", {
+            .get(`${API_BASE_URL}/leaderboard`, {
                 params: { year: leaderboardYear },
             })
             .then((response) => {
@@ -88,10 +87,7 @@ export default function App() {
         setLoadingLeague(true);
 
         axios
-            // .get("http://localhost:8081/leagueStats", {
-            .get("https://api.waroftheringcommunity.net:8080/leagueStats", {
-                params: leagueParams,
-            })
+            .get(`${API_BASE_URL}/leagueStats`, { params: leagueParams })
             .then((response) => setLeagueStats(response.data as LeagueStats))
             .catch((error) => {
                 setLeagueError(ErrorMessage.Default);
@@ -458,11 +454,9 @@ function Home({
                         onClick={() => {
                             setExporting(true);
                             axios
-                                .get(
-                                    // "http://localhost:8081/export",
-                                    "https://api.waroftheringcommunity.net:8080/export",
-                                    { responseType: "blob" }
-                                )
+                                .get(`${API_BASE_URL}/export`, {
+                                    responseType: "blob",
+                                })
                                 .then((response) => {
                                     // https://gist.github.com/javilobo8/097c30a233786be52070986d8cdb1743
                                     const blob = new Blob([response.data], {

--- a/frontend/src/GameReportForm/index.tsx
+++ b/frontend/src/GameReportForm/index.tsx
@@ -24,6 +24,7 @@ import {
     strongholds,
     victoryTypes,
 } from "../constants";
+import { API_BASE_URL } from "../env";
 import { GAME_FORM_BOLD } from "../styles/colors";
 import { toErrorMessage } from "../networkErrorHandlers";
 import {
@@ -609,8 +610,7 @@ export default GameReportForm;
 
 async function submit(validatedResult: ValidGameFormData) {
     return await axios.post(
-        // `http://localhost:8081/${
-        `https://api.waroftheringcommunity.net:8080/${
+        `${API_BASE_URL}/${
             typeof validatedResult.rid.value === "number"
                 ? "modifyReport"
                 : "submitReport"

--- a/frontend/src/GameReports.tsx
+++ b/frontend/src/GameReports.tsx
@@ -9,6 +9,7 @@ import ModalClose from "@mui/joy/ModalClose";
 import ModalDialog from "@mui/joy/ModalDialog";
 import Typography from "@mui/joy/Typography";
 import { ErrorMessage } from "./constants";
+import { API_BASE_URL } from "./env";
 import {
     Competition,
     Expansion,
@@ -75,16 +76,12 @@ export default function GameReports({
 
     const getReports = async (page: number) => {
         try {
-            const response = await axios.get(
-                // "http://localhost:8081/reports"
-                "https://api.waroftheringcommunity.net:8080/reports",
-                {
-                    params: {
-                        limit: PAGE_LIMIT,
-                        offset: getReportsOffset(page),
-                    },
-                }
-            );
+            const response = await axios.get(`${API_BASE_URL}/reports`, {
+                params: {
+                    limit: PAGE_LIMIT,
+                    offset: getReportsOffset(page),
+                },
+            });
             setReports(response.data.reports);
             setTotalReportCount(response.data.total);
         } catch (error) {

--- a/frontend/src/GoogleLogin.tsx
+++ b/frontend/src/GoogleLogin.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { CredentialResponse, GoogleLogin } from "@react-oauth/google";
 import axios from "axios";
 import { ErrorMessage } from "./constants";
+import { API_BASE_URL } from "./env";
 import { logNetworkError, toAuthStatus } from "./networkErrorHandlers";
 
 interface Props {
@@ -26,12 +27,9 @@ export default function GoogleLoginButton({
     const handleLoginSuccess = async (response: CredentialResponse) => {
         setLoadingUserInfo(true);
         await axios
-            .post(
-                // "http://localhost:8081/auth/google/login",
-                "https://api.waroftheringcommunity.net:8080/auth/google/login",
-                response.credential,
-                { headers: { "Content-Type": "text/plain;charset=utf-8" } }
-            )
+            .post(`${API_BASE_URL}/auth/google/login`, response.credential, {
+                headers: { "Content-Type": "text/plain;charset=utf-8" },
+            })
             .then(() => getUserInfo(onError))
             .catch((error) => {
                 onError(error);

--- a/frontend/src/LeaguePlayerForm.tsx
+++ b/frontend/src/LeaguePlayerForm.tsx
@@ -2,6 +2,7 @@ import axios from "axios";
 import React from "react";
 import Box from "@mui/joy/Box";
 import { ErrorMessage } from "./constants";
+import { API_BASE_URL } from "./env";
 import { toErrorMessage } from "./networkErrorHandlers";
 import {
     League,
@@ -102,15 +103,10 @@ export default function LeaguePlayerForm({
 }
 
 async function submit(validFormData: ValidLeaguePlayerFormData) {
-    return await axios.post(
-        "https://api.waroftheringcommunity.net:8080/addLeaguePlayer",
-        // "http://localhost:8081/addLeaguePlayer",
-        null,
-        {
-            headers: { "Content-Type": "application/json" },
-            params: toQueryParams(validFormData),
-        }
-    );
+    return await axios.post(`${API_BASE_URL}/addLeaguePlayer`, null, {
+        headers: { "Content-Type": "application/json" },
+        params: toQueryParams(validFormData),
+    });
 }
 
 type LeaguePlayerQueryParams = {

--- a/frontend/src/PlayerEditForm.tsx
+++ b/frontend/src/PlayerEditForm.tsx
@@ -8,6 +8,7 @@ import useFormData, { initializeToDefaults } from "./hooks/useFormData";
 import { toErrorMessage } from "./networkErrorHandlers";
 import Autocomplete from "./Autocomplete";
 import { COUNTRIES_DATA, optionalPlayerEditFields } from "./constants";
+import { API_BASE_URL } from "./env";
 
 interface Props {
     pid: number;
@@ -78,8 +79,7 @@ export default function PlayerEditForm({ pid, name, country, refresh }: Props) {
 
 async function submit(validFormData: ValidPlayerEditFormData) {
     return await axios.post(
-        "https://api.waroftheringcommunity.net:8080/editPlayer",
-        // "http://localhost:8081/editPlayer",
+        `${API_BASE_URL}/editPlayer`,
         toPayload(validFormData),
         {
             headers: { "Content-Type": "application/json" },

--- a/frontend/src/PlayerRemapForm.tsx
+++ b/frontend/src/PlayerRemapForm.tsx
@@ -11,6 +11,7 @@ import Autocomplete from "./Autocomplete";
 import useConditionalActionEffect from "./hooks/useConditionalActionEffect";
 import useFormData, { initializeToDefaults } from "./hooks/useFormData";
 import { ErrorMessage } from "./constants";
+import { API_BASE_URL } from "./env";
 import { toErrorMessage } from "./networkErrorHandlers";
 
 interface Props {
@@ -106,8 +107,7 @@ export default function PlayerRemapForm({
 
 async function submit(validFormData: ValidPlayerRemapFormData) {
     return await axios.post(
-        "https://api.waroftheringcommunity.net:8080/remapPlayer",
-        // "http://localhost:8081/remapPlayer",
+        `${API_BASE_URL}/remapPlayer`,
         toPayload(validFormData),
         {
             headers: { "Content-Type": "application/json" },

--- a/frontend/src/ReportDeleteForm.tsx
+++ b/frontend/src/ReportDeleteForm.tsx
@@ -1,6 +1,7 @@
 import axios from "axios";
 import React from "react";
 import AdminFormLayout from "./AdminFormLayout";
+import { API_BASE_URL } from "./env";
 import useConditionalActionEffect from "./hooks/useConditionalActionEffect";
 import useFormData, { initializeToDefaults } from "./hooks/useFormData";
 import { toErrorMessage } from "./networkErrorHandlers";
@@ -49,8 +50,7 @@ export default function ReportDeleteForm({
 
 async function submit({ rid }: ValidReportDeleteFormData) {
     return await axios.post(
-        "https://api.waroftheringcommunity.net:8080/deleteReport",
-        // "http://localhost:8081/deleteReport",
+        `${API_BASE_URL}/deleteReport`,
         { rid: rid.value },
         { headers: { "Content-Type": "application/json" } }
     );

--- a/frontend/src/env/dev.ts
+++ b/frontend/src/env/dev.ts
@@ -1,0 +1,3 @@
+import { Mode } from "./types";
+
+export const MODE: Mode = "dev";

--- a/frontend/src/env/env.d.ts
+++ b/frontend/src/env/env.d.ts
@@ -1,0 +1,4 @@
+declare module "env" {
+    const MODE: "prod" | "dev";
+    export const MODE;
+}

--- a/frontend/src/env/index.ts
+++ b/frontend/src/env/index.ts
@@ -4,4 +4,4 @@ export const isProd = MODE === "prod";
 
 export const API_BASE_URL = isProd
     ? "https://api.waroftheringcommunity.net:8080"
-    : "http://localhost:8081";
+    : "http://localhost:8080";

--- a/frontend/src/env/index.ts
+++ b/frontend/src/env/index.ts
@@ -1,0 +1,7 @@
+import { MODE } from "env";
+
+export const isProd = MODE === "prod";
+
+export const API_BASE_URL = isProd
+    ? "https://api.waroftheringcommunity.net:8080"
+    : "http://localhost:8081";

--- a/frontend/src/env/prod.ts
+++ b/frontend/src/env/prod.ts
@@ -1,0 +1,3 @@
+import { Mode } from "./types";
+
+export const MODE: Mode = "prod";

--- a/frontend/src/env/types.ts
+++ b/frontend/src/env/types.ts
@@ -1,0 +1,1 @@
+export type Mode = "prod" | "dev";

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -1,4 +1,4 @@
-const prod = process.env.NODE_ENV === "production";
+const isDev = process.env.NODE_ENV === "development";
 
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
@@ -6,7 +6,7 @@ const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const path = require("path");
 
 module.exports = {
-    mode: prod ? "production" : "development",
+    mode: isDev ? "development" : "production",
     entry: "./src/index.tsx",
     output: {
         path: path.resolve(__dirname + "/dist"),
@@ -19,7 +19,7 @@ module.exports = {
                 __dirname,
                 "src",
                 "env",
-                prod ? "prod.ts" : "dev.ts"
+                isDev ? "dev.ts" : "prod.ts"
             ),
         },
         extensions: [".ts", ".tsx", ".js", ".json"],

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -14,6 +14,14 @@ module.exports = {
     },
     target: "web",
     resolve: {
+        alias: {
+            env: path.resolve(
+                __dirname,
+                "src",
+                "env",
+                prod ? "prod.ts" : "dev.ts"
+            ),
+        },
         extensions: [".ts", ".tsx", ".js", ".json"],
     },
     module: {


### PR DESCRIPTION
Not sure if what I've done is unusual, but the general internet consensus keeps pointing me to using `process.env` by injecting a simulated `process.env` into the browser, and I don't understand why common practice is to pretend a node thing exists in the browser. It seems misleading on what runtime environment we're expecting to be in. I opted for this instead:
- Have two possible `env` files (`env/prod.ts` or `env/dev.ts`)
- Define an `env` file path alias in webpack
- Point the alias to the proper file depending on the webpack build mode