### PR TITLE
Clear autocomplete text on blur if nothing valid selected

### DIFF
--- a/frontend/src/Autocomplete.tsx
+++ b/frontend/src/Autocomplete.tsx
@@ -74,6 +74,7 @@ export default function Autocomplete<O extends string | MenuOption>({
                 onBlur={() => {
                     validate();
                     setDisplayedAlertText(alertText);
+                    if (!current) setLocalInputValue("");
                 }}
                 disabled={loading}
                 startDecorator={


### PR DESCRIPTION
Noticed this bug in passing, which currently only impacts the `country` form field when editing a player. If you type in a country that doesn't exist, country is correctly updated to `null` in form state. However, the local input value continues to display the search string you typed. So it **looks** like when you submit the form, it allows you to enter a country that doesn't exist; in fact, you're deleting the player's country by sending `null`.

TLDR: syncs up the displayed input value—which we allow to temporarily depart from form state, while user is typing to search—with actual form state, on blur of the field.