### PR TITLE
More relaxed logfile validation

### DIFF
--- a/backend/src/Validation.hs
+++ b/backend/src/Validation.hs
@@ -190,9 +190,10 @@ validateReport report =
 
 validateLogFile :: FilePath -> AppM ()
 validateLogFile fp = do
-  logFileText <- decodeLatin1 <$> readFileBS fp
-  unless (logFileHeader `T.isPrefixOf` logFileText) $ do
+  logFileLines <- take headerSearchSpan . lines . decodeLatin1 <$> readFileBS fp
+  unless (any (logFileHeader `T.isPrefixOf`) logFileLines) $ do
     logErrorN "Log file missing header."
     throwError $ err422 {errBody = "Invalid log file."}
   where
-    logFileHeader = "<auto> silent null\n"
+    headerSearchSpan = 5
+    logFileHeader = "<auto> silent null"


### PR DESCRIPTION
![](https://media.giphy.com/media/aJlKIh8Kh0NLa/giphy.gif?cid=790b7611br9a29mp943z4hi0ajh0ypcgpckynrerkmyhsdfc&ep=v1_gifs_search&rid=giphy.gif&ct=g)

Should handle a few known cases where logfiles fail our validation:

* Windows style line endings
* Manually edited logs where passwords are inserted on the first lines
* Older client versions which can output some additional info prior to the "silent null" header we look for