### PR TITLE
Amazonka logging

### DIFF
--- a/backend/app/Migration.hs
+++ b/backend/app/Migration.hs
@@ -1,7 +1,7 @@
 module Main where
 
 import Amazonka qualified as AWS
-import AppConfig (AppM, Env (..), authDatabaseFile, databaseFile, redisConfig, runAppLogger)
+import AppConfig (AppM, Env (..), authDatabaseFile, databaseFile, logFilter, redisConfig, runAppLogger)
 import AppServer (insertReport_, reprocessReports)
 import Control.Monad.Logger (LogLevel (..), MonadLogger)
 import Data.Csv (FromRecord, HasHeader (..), decode)
@@ -80,7 +80,7 @@ main = do
   dbPool <- runAppLogger logger $ createSqlitePoolWithConfig (toText databaseFile) defaultConnectionPoolConfig
   authDbPool <- runAppLogger logger $ createSqlitePoolWithConfig (toText authDatabaseFile) defaultConnectionPoolConfig
   redisPool <- connect redisConfig
-  aws <- AWS.newEnv AWS.discover >>= \awsEnv -> pure $ awsEnv {AWS.logger = toAwsLogger logger, AWS.region = AWS.Oregon}
+  aws <- AWS.newEnv AWS.discover >>= \awsEnv -> pure $ awsEnv {AWS.logger = toAwsLogger logFilter logger, AWS.region = AWS.Oregon}
 
   let env = Env {dbPool, authDbPool, redisPool, logger, aws}
 

--- a/backend/app/Server.hs
+++ b/backend/app/Server.hs
@@ -2,7 +2,7 @@ module Main where
 
 import Amazonka qualified as AWS
 import Api (API)
-import AppConfig (Env (..), authDatabaseFile, databaseFile, logFile, maxGameLogSizeMB, nt, redisConfig, runAppLogger)
+import AppConfig (Env (..), authDatabaseFile, databaseFile, logFile, logFilter, maxGameLogSizeMB, nt, redisConfig, runAppLogger)
 import AppServer (server)
 import Auth (authHandlerDev, authHandlerProd)
 import Control.Monad.Logger (LogLevel (..))
@@ -87,7 +87,7 @@ main = do
   dbPool <- runAppLogger logger $ createSqlitePoolWithConfig (toText databaseFile) defaultConnectionPoolConfig
   authDbPool <- runAppLogger logger $ createSqlitePoolWithConfig (toText authDatabaseFile) defaultConnectionPoolConfig
   redisPool <- connect redisConfig
-  aws <- AWS.newEnv AWS.discover >>= \awsEnv -> pure $ awsEnv {AWS.logger = toAwsLogger logger, AWS.region = AWS.Oregon}
+  aws <- AWS.newEnv AWS.discover >>= \awsEnv -> pure $ awsEnv {AWS.logger = toAwsLogger logFilter logger, AWS.region = AWS.Oregon}
 
   when doMigrate $ migrateSchema dbPool logger
 

--- a/backend/src/Logging.hs
+++ b/backend/src/Logging.hs
@@ -59,8 +59,10 @@ fromAwsLogLevel AWS.Debug = LevelDebug
 fromAwsLogLevel AWS.Info = LevelInfo
 fromAwsLogLevel AWS.Error = LevelError
 
-toAwsLogger :: Logger -> AWS.Logger
-toAwsLogger logger awsLevel builder = log logger (fromAwsLogLevel awsLevel) (toLogStr builder)
+toAwsLogger :: LogLevelFilter -> Logger -> AWS.Logger
+toAwsLogger logFilter logger awsLevel builder = when (logFilter "" logLevel) (log logger logLevel (toLogStr builder))
+  where
+    logLevel = fromAwsLogLevel awsLevel
 
 log :: Logger -> LogLevel -> LogStr -> IO ()
 log logger = logger defaultLoc ""

--- a/backend/src/Logging.hs
+++ b/backend/src/Logging.hs
@@ -1,5 +1,6 @@
 module Logging where
 
+import Amazonka qualified as AWS
 import Control.Monad.Logger (Loc, LogLevel (..), LogSource, LogStr, defaultLoc)
 import Network.Wai (Request)
 import System.Log.FastLogger
@@ -51,6 +52,15 @@ fileLogger path = do
   timeCache <- newTimeCache simpleTimeFormat
   (logger, _) <- newTimedFastLogger timeCache (LogFileNoRotate path defaultBufSize)
   pure $ \_ _ level msg -> logger (\time -> formatLogMsg time level msg)
+
+fromAwsLogLevel :: AWS.LogLevel -> LogLevel
+fromAwsLogLevel AWS.Trace = LevelDebug
+fromAwsLogLevel AWS.Debug = LevelDebug
+fromAwsLogLevel AWS.Info = LevelInfo
+fromAwsLogLevel AWS.Error = LevelError
+
+toAwsLogger :: Logger -> AWS.Logger
+toAwsLogger logger awsLevel builder = log logger (fromAwsLogLevel awsLevel) (toLogStr builder)
 
 log :: Logger -> LogLevel -> LogStr -> IO ()
 log logger = logger defaultLoc ""


### PR DESCRIPTION
![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExa2Ywa2p0ODBmeWRxZW9wbWtzeGlqdzhucjJnZ3g5ZmFqYnNmMjVkeiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/cPSeb8U6cjALDo0GGL/giphy.gif)

Resolves #106 

The Amazonka library (which handles all our AWS interactions for the backend) has its own logger, which doesn't interop with the logger we use for the rest of the app. This just provides a compatibility layer so that all the logging happens through our normal logger.