### PR TITLE
Frontend leagues filter in game reports table

### DIFF
--- a/backend/src/Database.hs
+++ b/backend/src/Database.hs
@@ -122,7 +122,9 @@ toFilterExpression report spec = foldr ((&&.) . fromMaybe (val True)) (val True)
             &&. ((report ^. GameReportWinnerId ==. val player2) ||. (report ^. GameReportLoserId ==. val player2))
     winnerFilter = toFilter report GameReportWinnerId spec.winners
     loserFilter = toFilter report GameReportLoserId spec.losers
-    leagueFilter = toFilter report GameReportLeague (map Just <$> spec.leagues)
+    leagueFilter = case spec.leagues of
+      Just [] -> Just (isNothing_ (report ^. GameReportLeague))
+      _ -> toFilter report GameReportLeague (map Just <$> spec.leagues)
 
 getAdminBySessionId :: (MonadIO m, MonadLogger m) => Text -> DBAction m (Maybe (Entity Admin))
 getAdminBySessionId sessionId = lift . getBy . UniqueAdminSessionId $ Just sessionId

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -59,7 +59,12 @@ export default function App() {
     const [exporting, setExporting] = useState(false);
 
     const playerOptions = leaderboard
-        .map((entry): MenuOption => ({ label: entry.name, id: entry.pid }))
+        .map(
+            (entry): MenuOption<number> => ({
+                label: entry.name,
+                id: entry.pid,
+            })
+        )
         .sort((a, b) => a.label.localeCompare(b.label));
 
     const playerNames = playerOptions.map(({ label }) => label);

--- a/frontend/src/Autocomplete.tsx
+++ b/frontend/src/Autocomplete.tsx
@@ -5,7 +5,7 @@ import MaterialAutocomplete from "@mui/joy/Autocomplete";
 import CircularProgress from "@mui/joy/CircularProgress";
 import { MenuOption } from "./types";
 
-interface Props<O extends string | MenuOption> {
+interface Props<O extends string | MenuOption<number | string>> {
     options: O[];
     current: O | null;
     placeholder: string;
@@ -17,7 +17,9 @@ interface Props<O extends string | MenuOption> {
     validate: () => void;
 }
 
-export default function Autocomplete<O extends string | MenuOption>({
+export default function Autocomplete<
+    O extends string | MenuOption<number | string>
+>({
     options,
     current,
     placeholder,

--- a/frontend/src/Autocomplete.tsx
+++ b/frontend/src/Autocomplete.tsx
@@ -5,7 +5,7 @@ import MaterialAutocomplete from "@mui/joy/Autocomplete";
 import CircularProgress from "@mui/joy/CircularProgress";
 import { MenuOption } from "./types";
 
-interface Props<O extends string | MenuOption<number | string>> {
+interface Props<O extends string | MenuOption<unknown>> {
     options: O[];
     current: O | null;
     placeholder: string;
@@ -17,9 +17,7 @@ interface Props<O extends string | MenuOption<number | string>> {
     validate: () => void;
 }
 
-export default function Autocomplete<
-    O extends string | MenuOption<number | string>
->({
+export default function Autocomplete<O extends string | MenuOption<unknown>>({
     options,
     current,
     placeholder,

--- a/frontend/src/GameReports.tsx
+++ b/frontend/src/GameReports.tsx
@@ -64,6 +64,9 @@ const LEAGUE_COL_WIDTH = 130;
 
 const PAGE_LIMIT = 100;
 
+const ALL_OPTION_ID = "ALL";
+const EMPTY_OPTION_ID = "EMPTY";
+
 interface Props {
     playerOptions: MenuOption<number>[];
     loadingPlayers: boolean;
@@ -262,13 +265,18 @@ export default function GameReports({
                                 <TableFilter
                                     placeholder="Select leagues"
                                     loading={false}
-                                    allOption={{ id: "", label: "Select all" }}
-                                    options={leagues.map(
-                                        (league): MenuOption<string> => ({
-                                            id: league,
-                                            label: getLeagueLabel(league),
-                                        })
-                                    )}
+                                    allOption={{
+                                        id: ALL_OPTION_ID,
+                                        label: "Any league",
+                                    }}
+                                    emptyOption={{
+                                        id: EMPTY_OPTION_ID,
+                                        label: "No league",
+                                    }}
+                                    options={leagues.map((league) => ({
+                                        id: league,
+                                        label: getLeagueLabel(league),
+                                    }))}
                                     width={LEAGUE_COL_WIDTH}
                                     current={filters.leagues}
                                     onChange={(values) => {
@@ -741,10 +749,10 @@ function isPairingValid(pairing: unknown[]) {
     return pairing.length <= 2;
 }
 
-function toFilterParam(
-    options: MenuOption<string | number>[]
-): (string | number)[] | null {
-    return nullifyEmpty(options.map(({ id }) => id));
+function toFilterParam(options: MenuOption<unknown>[]): unknown[] | null {
+    return options.find(({ id }) => id === EMPTY_OPTION_ID)
+        ? []
+        : nullifyEmpty(options.map(({ id }) => id));
 }
 
 function nullifyEmpty<T>(arr: T[]) {

--- a/frontend/src/PlayerRemapForm.tsx
+++ b/frontend/src/PlayerRemapForm.tsx
@@ -17,7 +17,7 @@ import { toErrorMessage } from "./networkErrorHandlers";
 interface Props {
     pid: number;
     name: string;
-    playerOptions: MenuOption[];
+    playerOptions: MenuOption<number>[];
     refresh: () => void;
 }
 

--- a/frontend/src/TableFilter.tsx
+++ b/frontend/src/TableFilter.tsx
@@ -6,23 +6,27 @@ import FormHelperText from "@mui/joy/FormHelperText";
 import { ErrorMessage } from "./constants";
 import { MenuOption } from "./types";
 
-interface Props<O extends string | MenuOption> {
+interface Props<O extends string | MenuOption<number | string>> {
     options: O[];
     current: O[];
     placeholder: string;
     loading: boolean;
     width: number;
     errorMessage?: ErrorMessage;
+    allOption?: O;
     onChange: (value: O[]) => void;
 }
 
-export default function TableFilter<O extends string | MenuOption>({
+export default function TableFilter<
+    O extends string | MenuOption<number | string>
+>({
     options,
     current,
     placeholder,
     loading,
     width,
     errorMessage,
+    allOption,
     onChange,
 }: Props<O>) {
     const [isFocused, setIsFocused] = useState(false);
@@ -53,12 +57,30 @@ export default function TableFilter<O extends string | MenuOption>({
                         size="sm"
                         limitTags={0}
                         placeholder={placeholder}
-                        options={options}
+                        options={
+                            allOption ? [allOption].concat(options) : options
+                        }
                         value={current}
                         loading={loading}
                         onFocus={() => setIsFocused(true)}
                         onBlur={() => setIsFocused(false)}
-                        onChange={(_, values) => onChange(values)}
+                        onChange={(_, values) => {
+                            if (allOption && values.includes(allOption)) {
+                                onChange(options);
+                            } else {
+                                onChange(
+                                    values.filter(
+                                        (value) => value !== allOption
+                                    )
+                                );
+                            }
+                        }}
+                        isOptionEqualToValue={(option, value) => {
+                            return typeof option === "string" ||
+                                typeof value === "string"
+                                ? option === value
+                                : option.id === value.id;
+                        }}
                         sx={{
                             background: "white",
                             fontSize: "inherit",

--- a/frontend/src/TableFilter.tsx
+++ b/frontend/src/TableFilter.tsx
@@ -119,8 +119,8 @@ export default function TableFilter<O extends Option>({
     );
 }
 
-function isOptionEqual(a?: Option, b?: Option) {
-    if (!a || !b) return false;
+function isOptionEqual(a: Option, b?: Option) {
+    if (!b) return false;
 
     return typeof a === "string" || typeof b === "string"
         ? a === b

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -153,9 +153,9 @@ export interface LeaderboardEntry {
 
 export type PlayerEditMode = "edit" | "remap";
 
-export type MenuOption = {
+export type MenuOption<T extends number | string> = {
     label: string;
-    id: number;
+    id: T;
 };
 
 export interface PlayerEditFormData {
@@ -173,8 +173,8 @@ export type ValidPlayerEditFormData = {
 };
 
 export interface PlayerRemapFormData {
-    fromPlayer: FieldData<MenuOption>;
-    toPlayer: FieldData<MenuOption | null>;
+    fromPlayer: FieldData<MenuOption<number>>;
+    toPlayer: FieldData<MenuOption<number> | null>;
 }
 
 export type ValidPlayerRemapFormData = {
@@ -244,8 +244,9 @@ export type ValidLeaguePlayerFormData = {
 export type ValueOf<T> = T[keyof T];
 
 export type GameReportFilters = {
-    pairing: MenuOption[];
-    players: MenuOption[];
-    winners: MenuOption[];
-    losers: MenuOption[];
+    pairing: MenuOption<number>[];
+    players: MenuOption<number>[];
+    winners: MenuOption<number>[];
+    losers: MenuOption<number>[];
+    leagues: MenuOption<string>[];
 };

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -153,7 +153,7 @@ export interface LeaderboardEntry {
 
 export type PlayerEditMode = "edit" | "remap";
 
-export type MenuOption<T extends number | string> = {
+export type MenuOption<T> = {
     label: string;
     id: T;
 };


### PR DESCRIPTION
| No selections, closed | Open | After clicking "Any league" | After clicking "No league" | With selections, closed |
|-|-|-|-|-|
| ![image](https://github.com/user-attachments/assets/65c9491d-ebd1-4a31-a75f-e9478cffba9f) | ![image](https://github.com/user-attachments/assets/457d2c1f-98ee-4969-8ca3-36dbde9bf2c5) | ![image](https://github.com/user-attachments/assets/392b20e3-3168-47df-8823-fe196c5784c5) | ![image](https://github.com/user-attachments/assets/2379e660-68ab-48f9-8d53-8ded4919de93) | ![image](https://github.com/user-attachments/assets/e09b33b2-2a29-4d07-b049-bf9fa4bdf31b) |

- This was super quick to implement until I dove into the "any league" and "no league" options - hopefully establishing a pattern with this PR will make the other filters progressively faster!

- I didn't get fancy with the "any league" option; it's just a button that selects all the leagues for you (e.g. it doesn't deselect all leagues if you reclick, or flip to highlighted if you manually select all leagues - etc.)

- The "No league" option was weird. I included a backend adjustment for translating the meaning of an empty list, and also realized we don't have a way to filter for a mix of no-league and league - e.g. "game reports with no league OR with the WoME league". Maybe that would look like `[null, WoMELeague, ..etc]`, which would require more backend finagling than I wanted to do at the moment, and I don't think there's an urgent need 😬 