### PR TITLE
Tools menu + logout

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,7 +16,6 @@ import List from "@mui/joy/List";
 import ListItemButton from "@mui/joy/ListItemButton";
 import MenuIcon from "@mui/icons-material/Menu";
 import Typography from "@mui/joy/Typography";
-import WarningIcon from "@mui/icons-material/Warning";
 import { BrowserRouter, Routes, Route, Link } from "react-router-dom";
 import { ErrorMessage } from "./constants";
 import { logNetworkError } from "./networkErrorHandlers";
@@ -30,8 +29,8 @@ import {
 } from "./types";
 import { API_BASE_URL } from "./env";
 import { GoogleOAuthProvider } from "@react-oauth/google";
-import GoogleLoginButton from "./GoogleLogin";
 import Leagues from "./Leagues";
+import ToolsMenu from "./ToolsMenu";
 
 export default function App() {
     const [userInfo, setUserInfo] = useState<UserInfo | null>(null);
@@ -168,13 +167,6 @@ export default function App() {
                         >
                             {loadingUserInfo ? (
                                 <CircularProgress size="sm" />
-                            ) : loginError ? (
-                                <>
-                                    <WarningIcon
-                                        sx={{ color: "inherit", mx: "5px" }}
-                                    />
-                                    {loginError}
-                                </>
                             ) : (
                                 userInfo?.isAdmin && (
                                     <>
@@ -185,22 +177,22 @@ export default function App() {
                                     </>
                                 )
                             )}
+
+                            <ToolsMenu
+                                loadingUserInfo={loadingUserInfo}
+                                loginError={loginError}
+                                userInfo={userInfo}
+                                exporting={exporting}
+                                getUserInfo={getUserInfo}
+                                clearUserInfo={clearUserInfo}
+                                setLoginError={setLoginError}
+                                setLoadingUserInfo={setLoadingUserInfo}
+                                setExporting={setExporting}
+                            />
                         </Box>
                     </header>
                     <Routes>
-                        <Route
-                            path="/"
-                            element={
-                                <Home
-                                    getUserInfo={getUserInfo}
-                                    clearUserInfo={clearUserInfo}
-                                    setLoginError={setLoginError}
-                                    setLoadingUserInfo={setLoadingUserInfo}
-                                    exporting={exporting}
-                                    setExporting={setExporting}
-                                />
-                            }
-                        />
+                        <Route path="/" element={<Home />} />
                         <Route
                             path="/game-report"
                             element={
@@ -258,23 +250,7 @@ export default function App() {
     );
 }
 
-interface HomeProps {
-    getUserInfo: (onError: (error: unknown) => void) => void;
-    clearUserInfo: () => void;
-    setLoginError: (error: string) => void;
-    setLoadingUserInfo: (loading: boolean) => void;
-    exporting: boolean;
-    setExporting: (exporting: boolean) => void;
-}
-
-function Home({
-    getUserInfo,
-    clearUserInfo,
-    setLoginError,
-    setLoadingUserInfo,
-    exporting,
-    setExporting,
-}: HomeProps) {
+function Home() {
     return (
         <Box
             gap={3}
@@ -445,61 +421,6 @@ function Home({
                         {label}
                     </ExternalLink>
                 ))}
-            </Section>
-            <Section>
-                <Typography level="title-lg" mb={1}>
-                    Admin Tools
-                </Typography>
-
-                <Box display="flex" flexDirection="row" gap={1}>
-                    <GoogleLoginButton
-                        getUserInfo={getUserInfo}
-                        clearUserInfo={clearUserInfo}
-                        setLoginError={setLoginError}
-                        setLoadingUserInfo={setLoadingUserInfo}
-                    />
-                    <Button
-                        variant="outlined"
-                        loading={exporting}
-                        onClick={() => {
-                            setExporting(true);
-                            axios
-                                .get(`${API_BASE_URL}/export`, {
-                                    responseType: "blob",
-                                })
-                                .then((response) => {
-                                    // https://gist.github.com/javilobo8/097c30a233786be52070986d8cdb1743
-                                    const blob = new Blob([response.data], {
-                                        type: response.data.type,
-                                    });
-                                    const url =
-                                        window.URL.createObjectURL(blob);
-                                    const link = document.createElement("a");
-                                    link.href = url;
-                                    const contentDisposition =
-                                        response.headers["content-disposition"];
-                                    let fileName = "export.zip";
-                                    if (contentDisposition) {
-                                        const fileNameMatch =
-                                            contentDisposition.match(
-                                                /filename="(.+)"/
-                                            );
-                                        if (fileNameMatch.length === 2)
-                                            fileName = fileNameMatch[1];
-                                    }
-                                    link.setAttribute("download", fileName);
-                                    document.body.appendChild(link);
-                                    link.click();
-                                    link.remove();
-                                    window.URL.revokeObjectURL(url);
-                                })
-                                .catch(logNetworkError)
-                                .finally(() => setExporting(false));
-                        }}
-                    >
-                        Export Data
-                    </Button>
-                </Box>
             </Section>
 
             <Section>

--- a/frontend/src/ErrorDisplay.tsx
+++ b/frontend/src/ErrorDisplay.tsx
@@ -1,8 +1,8 @@
 import React, { ReactNode } from "react";
 import Typography from "@mui/joy/Typography";
-import ExternalLink from "./ExternalLink";
 import { SxProps } from "@mui/joy/styles/types";
 import { ErrorMessage } from "./constants";
+import SupportLink from "./SupportLink";
 
 interface Props {
     message: ReactNode;
@@ -11,16 +11,9 @@ interface Props {
 
 export default function ErrorDisplay({ message, sx = {} }: Props) {
     return (
-        <Typography color="danger" display="flex" alignItems="center" sx={sx}>
+        <Typography color="danger" sx={sx}>
             {message}
-            {message === ErrorMessage.Default && (
-                <ExternalLink
-                    href="https://discord.com/channels/590789678890745857/818775910748258326"
-                    style={{ paddingLeft: "4px" }}
-                >
-                    Discord support channel
-                </ExternalLink>
-            )}
+            {message === ErrorMessage.Default && <SupportLink />}
         </Typography>
     );
 }

--- a/frontend/src/ExternalLink.tsx
+++ b/frontend/src/ExternalLink.tsx
@@ -22,7 +22,7 @@ export default function ExternalLink({
             href={href}
             target="_blank"
             rel="noopener noreferrer"
-            style={style}
+            sx={style}
         >
             <Icon sx={{ paddingRight: "5px" }} />
             {children}

--- a/frontend/src/Modal.tsx
+++ b/frontend/src/Modal.tsx
@@ -1,0 +1,53 @@
+import React, { ReactNode } from "react";
+import MaterialModal from "@mui/joy/Modal";
+import ModalClose from "@mui/joy/ModalClose";
+import Sheet from "@mui/joy/Sheet";
+import Typography from "@mui//joy/Typography";
+
+interface Props {
+    isOpen: boolean;
+    close: () => void;
+    title: ReactNode;
+    children: ReactNode;
+}
+
+export default function Modal({ isOpen, close, title, children }: Props) {
+    return (
+        <MaterialModal
+            aria-labelledby="modal-title"
+            aria-describedby="modal-desc"
+            open={isOpen}
+            onClose={close}
+            sx={{
+                display: "flex",
+                justifyContent: "center",
+                alignItems: "center",
+            }}
+        >
+            <Sheet
+                variant="outlined"
+                sx={{
+                    maxWidth: 500,
+                    borderRadius: "md",
+                    p: 3,
+                    boxShadow: "lg",
+                }}
+            >
+                <ModalClose variant="plain" sx={{ m: 1 }} />
+
+                <Typography
+                    id="modal-title"
+                    level="h4"
+                    textColor="inherit"
+                    sx={{ fontWeight: "lg", mb: 1 }}
+                >
+                    {title}
+                </Typography>
+
+                <Typography id="modal-desc" textColor="text.tertiary">
+                    {children}
+                </Typography>
+            </Sheet>
+        </MaterialModal>
+    );
+}

--- a/frontend/src/SupportLink.tsx
+++ b/frontend/src/SupportLink.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import ExternalLink from "./ExternalLink";
+
+export default function SupportLink() {
+    return (
+        <ExternalLink
+            href="https://discord.com/channels/590789678890745857/818775910748258326"
+            style={{
+                paddingLeft: "4px",
+                top: "4px",
+            }}
+        >
+            Discord support channel
+        </ExternalLink>
+    );
+}

--- a/frontend/src/ToolsMenu.tsx
+++ b/frontend/src/ToolsMenu.tsx
@@ -88,7 +88,7 @@ export default function ToolsMenu({
             .catch((error) => {
                 logNetworkError(error);
                 setErrorData({
-                    title: "There is some new devilry here",
+                    title: "There is some new devilry here...",
                     message: ErrorMessage.ExportError,
                 });
             })

--- a/frontend/src/ToolsMenu.tsx
+++ b/frontend/src/ToolsMenu.tsx
@@ -95,7 +95,7 @@ export default function ToolsMenu({
             .finally(() => setExporting(false));
     };
 
-    const handleLogout = async () => {
+    const handleLogout = () => {
         const onError = (error: unknown) => {
             logNetworkError(error);
             setErrorData({
@@ -105,15 +105,11 @@ export default function ToolsMenu({
         };
 
         setLoadingUserInfo(true);
-        try {
-            googleLogout();
-            await axios
-                .post(`${API_BASE_URL}/logout`)
-                .then(() => getUserInfo(onError));
-        } catch (error) {
-            onError(error);
-        }
-        setLoadingUserInfo(false);
+        axios
+            .post(`${API_BASE_URL}/logout`)
+            .then(() => getUserInfo(onError))
+            .catch(onError)
+            .finally(() => setLoadingUserInfo(false));
     };
 
     return (

--- a/frontend/src/ToolsMenu.tsx
+++ b/frontend/src/ToolsMenu.tsx
@@ -51,8 +51,8 @@ export default function ToolsMenu({
     useEffect(() => {
         if (loginError) {
             setErrorData({
-                title: ErrorMessage.NotAuthorizedStatus,
-                message: ErrorMessage.NotAuthorized,
+                title: loginError,
+                message: ErrorMessage.LoginError,
             });
         }
     }, [loginError]);

--- a/frontend/src/ToolsMenu.tsx
+++ b/frontend/src/ToolsMenu.tsx
@@ -1,0 +1,275 @@
+import axios from "axios";
+import React, { CSSProperties, ReactNode, useEffect, useState } from "react";
+import { googleLogout } from "@react-oauth/google";
+import Box from "@mui/joy/Box";
+import CircularProgress from "@mui/joy/CircularProgress";
+import Dropdown from "@mui/joy/Dropdown";
+import ExportIcon from "@mui/icons-material/FileDownload";
+import LoginIcon from "@mui/icons-material/Login";
+import LogoutIcon from "@mui/icons-material/Logout";
+import Menu from "@mui/joy/Menu";
+import MenuButton from "@mui/joy/MenuButton";
+import MenuItem from "@mui/joy/MenuItem";
+import ToolboxIcon from "@mui/icons-material/HomeRepairService";
+import GoogleLoginButton from "./GoogleLogin";
+import Modal from "./Modal";
+import SupportLink from "./SupportLink";
+import { ErrorMessage } from "./constants";
+import { UserInfo } from "./types";
+import { API_BASE_URL } from "./env";
+import { logNetworkError } from "./networkErrorHandlers";
+
+interface Props {
+    loadingUserInfo: boolean;
+    loginError: string | null;
+    userInfo: UserInfo | null;
+    exporting: boolean;
+    getUserInfo: (onError: (error: unknown) => void) => void;
+    clearUserInfo: () => void;
+    setLoginError: (error: string | null) => void;
+    setLoadingUserInfo: (loading: boolean) => void;
+    setExporting: (exporting: boolean) => void;
+}
+
+export default function ToolsMenu({
+    loadingUserInfo,
+    loginError,
+    userInfo,
+    exporting,
+    getUserInfo,
+    clearUserInfo,
+    setLoginError,
+    setLoadingUserInfo,
+    setExporting,
+}: Props) {
+    const [isOpen, setIsOpen] = useState(false);
+    const [errorData, setErrorData] = useState<{
+        title: ReactNode;
+        message: ReactNode;
+    } | null>(null);
+
+    useEffect(() => {
+        if (loginError) {
+            setErrorData({
+                title: ErrorMessage.NotAuthorizedStatus,
+                message: ErrorMessage.NotAuthorized,
+            });
+        }
+    }, [loginError]);
+
+    const handleExport = () => {
+        setExporting(true);
+        axios
+            .get(`${API_BASE_URL}/export`, {
+                responseType: "blob",
+            })
+            .then((response) => {
+                // https://gist.github.com/javilobo8/097c30a233786be52070986d8cdb1743
+                const blob = new Blob([response.data], {
+                    type: response.data.type,
+                });
+                const url = window.URL.createObjectURL(blob);
+                const link = document.createElement("a");
+                link.href = url;
+                const contentDisposition =
+                    response.headers["content-disposition"];
+                let fileName = "export.zip";
+                if (contentDisposition) {
+                    const fileNameMatch =
+                        contentDisposition.match(/filename="(.+)"/);
+                    if (fileNameMatch.length === 2) fileName = fileNameMatch[1];
+                }
+                link.setAttribute("download", fileName);
+                document.body.appendChild(link);
+                link.click();
+                link.remove();
+                window.URL.revokeObjectURL(url);
+            })
+            .catch((error) => {
+                logNetworkError(error);
+                setErrorData({
+                    title: "There is some new devilry here",
+                    message: ErrorMessage.ExportError,
+                });
+            })
+            .finally(() => setExporting(false));
+    };
+
+    const handleLogout = async () => {
+        const onError = (error: unknown) => {
+            logNetworkError(error);
+            setErrorData({
+                title: "The way is shut.",
+                message: ErrorMessage.LogoutError,
+            });
+        };
+
+        setLoadingUserInfo(true);
+        try {
+            googleLogout();
+            await axios
+                .post(`${API_BASE_URL}/logout`)
+                .then(() => getUserInfo(onError));
+        } catch (error) {
+            onError(error);
+        }
+        setLoadingUserInfo(false);
+    };
+
+    return (
+        <Dropdown open={isOpen} onOpenChange={(_, isOpen) => setIsOpen(isOpen)}>
+            <Modal
+                isOpen={!!errorData}
+                close={() => {
+                    setErrorData(null);
+                    setLoginError(null);
+                }}
+                title={errorData?.title}
+            >
+                {errorData?.message}
+                <SupportLink />
+            </Modal>
+
+            <ToolsButton loading={exporting || loadingUserInfo} />
+
+            <Menu>
+                <Item disabled={exporting} onClick={handleExport}>
+                    <ExportIcon sx={{ mr: 1 }} />
+                    Export Data
+                </Item>
+
+                {userInfo?.isAdmin ? (
+                    <Item
+                        disabled={loadingUserInfo}
+                        onClick={handleLogout}
+                        containerStyle={{ padding: 1 }}
+                    >
+                        <LogoutIcon sx={{ mr: 1, pl: "3px" }} />
+                        Sign Out
+                    </Item>
+                ) : (
+                    <MaskedItem
+                        disabled={loadingUserInfo}
+                        maskChildren={
+                            <>
+                                <LoginIcon sx={{ mr: 1 }} />
+                                Admin Sign-In
+                            </>
+                        }
+                    >
+                        <GoogleLoginButton
+                            getUserInfo={getUserInfo}
+                            clearUserInfo={clearUserInfo}
+                            setLoginError={setLoginError}
+                            setLoadingUserInfo={setLoadingUserInfo}
+                        />
+                    </MaskedItem>
+                )}
+            </Menu>
+        </Dropdown>
+    );
+}
+
+interface ContainerProps {
+    children: ReactNode;
+}
+
+interface ToolsButtonProps {
+    loading: boolean;
+}
+
+function ToolsButton({ loading }: ToolsButtonProps) {
+    return (
+        <MenuButton
+            variant="plain"
+            size="lg"
+            sx={{
+                p: "5px",
+                m: "5px",
+                mr: 0,
+                minHeight: 0,
+                color: "inherit",
+            }}
+        >
+            {loading ? (
+                <CircularProgress size="sm" />
+            ) : (
+                <ToolboxIcon sx={{ color: "inherit", mx: "5px" }} />
+            )}
+        </MenuButton>
+    );
+}
+
+type ItemProps = ContainerProps & {
+    disabled?: boolean;
+    containerStyle?: CSSProperties;
+    onClick?: () => void;
+};
+
+function Item({ children, disabled, containerStyle = {}, onClick }: ItemProps) {
+    return (
+        <MenuItem disabled={disabled} sx={{ p: 0 }} onClick={onClick}>
+            <Box
+                sx={{
+                    display: "flex",
+                    alignItems: "center",
+                    p: 1,
+                    width: "100%",
+                    ...containerStyle,
+                }}
+            >
+                {children}
+            </Box>
+        </MenuItem>
+    );
+}
+
+type MaskedItemProps = ContainerProps & {
+    disabled: boolean;
+    maskChildren: ReactNode;
+};
+
+function MaskedItem({ disabled, maskChildren, children }: MaskedItemProps) {
+    return (
+        <Item
+            disabled={disabled}
+            containerStyle={{ position: "relative", padding: 0 }}
+        >
+            <ItemMask>{maskChildren}</ItemMask>
+            <InvisibleOverlay>{!disabled && children}</InvisibleOverlay>
+        </Item>
+    );
+}
+
+function ItemMask({ children }: ContainerProps) {
+    return (
+        <Box
+            sx={{
+                position: "relative",
+                zIndex: 1,
+                display: "flex",
+                alignItems: "center",
+                p: 1,
+            }}
+        >
+            {children}
+        </Box>
+    );
+}
+
+function InvisibleOverlay({ children }: ContainerProps) {
+    return (
+        <Box
+            sx={{
+                position: "absolute",
+                width: "100%",
+                zIndex: 2,
+                opacity: 0,
+                p: 0,
+                m: 0,
+            }}
+        >
+            {children}
+        </Box>
+    );
+}

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -115,7 +115,7 @@ export const playerStates = ["Active", "Inactive"] as const;
 
 export enum ErrorMessage {
     Default = "Something went wrong. Please contact an admin for assistance.",
-    NotAuthorized = "You cannot pass! If you're an administrator, your session may have expired. Please log in and try again.",
+    NotAuthorized = "If you're an administrator, your session may have expired. Please log in and try again.",
     NotAuthorizedStatus = "You cannot pass!",
     UnknownAuthStatus = "Sign-in unavailable",
     Required = "Required",
@@ -123,6 +123,8 @@ export enum ErrorMessage {
     MissingPlayerName = "This player does not exist in the database. Unless it's a new player, please check the spelling.",
     ExistingPlayerRequired = "Must choose an existing player",
     PairingFilterInvalid = "Select up to two",
+    LogoutError = "Failed to sign out. Please contact an admin for assistance.",
+    ExportError = "Failed to export data. Please contact an admin for assistance.",
 }
 
 export const INFINITE = 100;

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -123,6 +123,7 @@ export enum ErrorMessage {
     MissingPlayerName = "This player does not exist in the database. Unless it's a new player, please check the spelling.",
     ExistingPlayerRequired = "Must choose an existing player",
     PairingFilterInvalid = "Select up to two",
+    LoginError = "Failed to sign in. Non-administrators can't sign in. If you're an administrator, please request support on Discord.",
     LogoutError = "Failed to sign out. Please contact an admin for assistance.",
     ExportError = "Failed to export data. Please contact an admin for assistance.",
 }

--- a/frontend/src/networkErrorHandlers.ts
+++ b/frontend/src/networkErrorHandlers.ts
@@ -4,7 +4,7 @@ import { ServerErrorBody } from "./types";
 export function toErrorMessage(error: ServerErrorBody): string {
     switch (error.status) {
         case 401:
-            return ErrorMessage.NotAuthorized;
+            return `${ErrorMessage.NotAuthorizedStatus} ${ErrorMessage.NotAuthorized}`;
         case 422:
             return error.response.data;
         default:


### PR DESCRIPTION
Resolves #188
Resolves #175 

1. Move admin sign-in and export buttons into a header tools menu, and mask the google sign-in text with "admin sign-in":

![image](https://github.com/user-attachments/assets/bdc39d4a-b741-40e5-9b82-784d4ced5a80)

2. Add logout:

![image](https://github.com/user-attachments/assets/747fb2b6-165b-43a3-a3fa-cc9d84ac3248)

3. Display related errors in clearable warning popups (instead of a persistent warning message in the header):

| | | |
|-|-|-|
| ![image](https://github.com/user-attachments/assets/7c220e6a-a83f-4556-afaf-1a5eef37086e) | ![image](https://github.com/user-attachments/assets/7deb9017-d663-4dde-b632-1acc028d224a) | ![image](https://github.com/user-attachments/assets/37520b01-c9aa-4976-bc5c-64a39ef2a234) |

Partially confirmed a logout request works, because it clears the session ID from my local database for a user "Frodo," which is the dummy user ID in `authHandlerDev`. But have no idea on the Google side of things via `googleLogout` - think that half can only be verified in prod.