### PR TITLE
Add loading spinner in sign-in popup

### DIFF
--- a/frontend/src/ToolsMenu.tsx
+++ b/frontend/src/ToolsMenu.tsx
@@ -137,8 +137,14 @@ export default function ToolsMenu({
                 close={() => setIsLoginModalOpen(false)}
                 title={"Admin Sign-In"}
             >
-                {userInfo?.isAdmin ? (
-                    <Box width={200}>Signed in</Box>
+                {loadingUserInfo || userInfo?.isAdmin ? (
+                    <Box width={200}>
+                        {loadingUserInfo ? (
+                            <CircularProgress size="sm" />
+                        ) : (
+                            "Signed in"
+                        )}
+                    </Box>
                 ) : (
                     <GoogleLoginButton
                         getUserInfo={getUserInfo}


### PR DESCRIPTION
Loading spinner to fix a little flicker between the sign-in button and the success message after signing in

![image](https://github.com/user-attachments/assets/b253a66f-603a-4a82-ba96-f11696568d6b)
