### PR TITLE
Extract repeated HTTP request state management into a hook

### DIFF
--- a/frontend/src/GoogleLogin.tsx
+++ b/frontend/src/GoogleLogin.tsx
@@ -8,7 +8,7 @@ import { logNetworkError, toAuthStatus } from "./networkErrorHandlers";
 interface Props {
     getUserInfo: (onError: (error: unknown) => void) => void;
     clearUserInfo: () => void;
-    setLoginError: (error: string) => void;
+    setLoginError: (error: ErrorMessage) => void;
     setLoadingUserInfo: (loading: boolean) => void;
 }
 

--- a/frontend/src/Rankings.tsx
+++ b/frontend/src/Rankings.tsx
@@ -32,6 +32,7 @@ import TableLayout from "./TableLayout";
 import { range, toPercent } from "./utils";
 import {
     COUNTRIES_DATA,
+    ErrorMessage,
     LEADERBOARD_START_YEAR,
     playerStates,
 } from "./constants";
@@ -44,14 +45,13 @@ type PlayerEditParams = {
 };
 
 interface Props {
-    leaderboard: LeaderboardEntry[];
+    entries: LeaderboardEntry[];
     year: number;
     loading: boolean;
     error: string | null;
     isAdmin: boolean;
     getLeaderboard: () => void;
     setYear: (year: number) => void;
-    setError: (error: string | null) => void;
 }
 
 const HEADER_ROW_HEIGHT = 32;
@@ -64,24 +64,18 @@ const TABLE_TOP_POSITION =
     TABLE_ELEMENTS_GAP * 3;
 
 function Rankings({
-    leaderboard,
+    entries,
     year,
     loading,
     error,
     isAdmin,
     getLeaderboard,
     setYear,
-    setError,
 }: Props) {
     const [filters, setFilters] = useState<PlayerState[]>(["Active"]);
 
     const [playerEditParams, setPlayerEditParams] =
         useState<PlayerEditParams | null>(null);
-
-    const refresh = () => {
-        setError(null);
-        getLeaderboard();
-    };
 
     const availableYears = range(
         LEADERBOARD_START_YEAR,
@@ -97,8 +91,8 @@ function Rankings({
                         {playerEditParams.mode === "remap" ? (
                             <PlayerRemapForm
                                 {...playerEditParams}
-                                refresh={refresh}
-                                playerOptions={leaderboard.map((entry) => ({
+                                refresh={getLeaderboard}
+                                playerOptions={entries.map((entry) => ({
                                     label: entry.name,
                                     id: entry.pid,
                                 }))}
@@ -106,7 +100,7 @@ function Rankings({
                         ) : (
                             <PlayerEditForm
                                 {...playerEditParams}
-                                refresh={refresh}
+                                refresh={getLeaderboard}
                             />
                         )}
                     </ModalDialog>
@@ -120,7 +114,7 @@ function Rankings({
             />
 
             <TableLayout
-                refresh={refresh}
+                refresh={getLeaderboard}
                 error={error}
                 loading={loading}
                 label="Rankings"
@@ -210,7 +204,7 @@ function Rankings({
                         </TableHeaderRow>
                     </>
                 }
-                body={leaderboard
+                body={entries
                     .filter(
                         (entry) =>
                             (entry.isActive && filters.includes("Active")) ||

--- a/frontend/src/ToolsMenu.tsx
+++ b/frontend/src/ToolsMenu.tsx
@@ -22,27 +22,24 @@ interface Props {
     loadingUserInfo: boolean;
     loginError: string | null;
     userInfo: UserInfo | null;
-    exporting: boolean;
     getUserInfo: (onError: (error: unknown) => void) => void;
     clearUserInfo: () => void;
-    setLoginError: (error: string | null) => void;
+    setLoginError: (error: ErrorMessage | null) => void;
     setLoadingUserInfo: (loading: boolean) => void;
-    setExporting: (exporting: boolean) => void;
 }
 
 export default function ToolsMenu({
     loadingUserInfo,
     loginError,
     userInfo,
-    exporting,
     getUserInfo,
     clearUserInfo,
     setLoginError,
     setLoadingUserInfo,
-    setExporting,
 }: Props) {
     const [isOpen, setIsOpen] = useState(false);
     const [isLoginModalOpen, setIsLoginModalOpen] = useState(false);
+    const [exporting, setExporting] = useState(false);
     const [errorData, setErrorData] = useState<{
         title: ReactNode;
         message: ReactNode;

--- a/frontend/src/hooks/useRequestState.tsx
+++ b/frontend/src/hooks/useRequestState.tsx
@@ -1,0 +1,42 @@
+import { useState } from "react";
+import { ErrorMessage } from "../constants";
+import { logNetworkError } from "../networkErrorHandlers";
+
+type RequestWithState = (onError?: (err: unknown) => void) => void;
+
+type State<T, I> = [T | I, boolean, ErrorMessage | null];
+
+type Setters<T, I> = [
+    React.Dispatch<React.SetStateAction<T | I>>,
+    React.Dispatch<React.SetStateAction<boolean>>,
+    React.Dispatch<React.SetStateAction<ErrorMessage | null>>
+];
+
+interface Response {
+    data: any;
+}
+
+export default function useRequestState<T, I>(
+    initialData: I,
+    sendRequest: () => Promise<Response>
+): [RequestWithState, State<T, I>, Setters<T, I>] {
+    const [data, setData] = useState<T | I>(initialData);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState<ErrorMessage | null>(null);
+
+    const request: RequestWithState = (
+        onError = (err) => {
+            logNetworkError(err);
+            setError(ErrorMessage.Default);
+        }
+    ) => {
+        setLoading(true);
+        setError(null);
+        sendRequest()
+            .then((res) => setData(res.data as T))
+            .catch(onError)
+            .finally(() => setLoading(false));
+    };
+
+    return [request, [data, loading, error], [setData, setLoading, setError]];
+}

--- a/frontend/src/networkErrorHandlers.ts
+++ b/frontend/src/networkErrorHandlers.ts
@@ -12,7 +12,7 @@ export function toErrorMessage(error: ServerErrorBody): string {
     }
 }
 
-export function toAuthStatus(error: unknown): string {
+export function toAuthStatus(error: unknown): ErrorMessage {
     if (isServerError(error) && error.status === 401) {
         return ErrorMessage.NotAuthorizedStatus;
     }


### PR DESCRIPTION
Some groundwork before #67 - extracts some repetitive state management code into a hook before sticking similar state management for the 4th/last network call into the app root.