### PR TITLE
Add/update landing page links

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -281,7 +281,7 @@ function Home() {
                     },
                     {
                         label: "Discord",
-                        href: "https://discord.gg/yZxQF4fK",
+                        href: "https://discord.gg/DUdcpdyNMm",
                         isDownload: false,
                     },
                 ].map(({ label, href, isDownload }) => (
@@ -310,6 +310,34 @@ function Home() {
                     {
                         label: "WotR Almanac: KoME",
                         href: "https://tinyurl.com/KOMEAlmanac",
+                        isDownload: false,
+                    },
+                    {
+                        label: "League Rules",
+                        href: "https://docs.google.com/document/d/1T2OIOfU9vlSJQd0xPoivFmHOUTvPOa1jjtaiN2vrHAQ",
+                        isDownload: false,
+                    },
+                ].map(({ label, href, isDownload }) => (
+                    <ExternalLink
+                        href={href}
+                        isDownload={isDownload}
+                        key={label}
+                    >
+                        {label}
+                    </ExternalLink>
+                ))}
+
+                <Subtitle>Technical Support</Subtitle>
+
+                {[
+                    {
+                        label: "Java Client & Hamachi Setup",
+                        href: "https://www.youtube.com/watch?v=g6xt-xC9dXY",
+                        isDownload: false,
+                    },
+                    {
+                        label: "ZeroTier Setup",
+                        href: "https://www.youtube.com/watch?v=mKkia_KGzzo",
                         isDownload: false,
                     },
                 ].map(({ label, href, isDownload }) => (


### PR DESCRIPTION
Resolves #248 

Added `League Rules` under the `Rules Clarifications and FAQ` section, and also added a new `Technical Support` section with a couple links, since I've been meaning to and was in the area. And I updated the discord invite link - I think the current link is to an expired invite, but this new one doesn't expire.

I have plans to make the landing page prettier instead of a single column down the center like this - I like the current layout for mobile, but for desktop screen sizes, it would be cool to use a bit more of the horizontal space instead of needing to scroll.

![image](https://github.com/user-attachments/assets/aed2786f-fc9d-4fd4-95f4-ed31b667fe32)
