### PR TITLE
Clear autocomplete alert immediately when alert is resolved

### DIFF
--- a/frontend/src/Autocomplete.tsx
+++ b/frontend/src/Autocomplete.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useState } from "react";
+import React, { ReactNode, useEffect, useState } from "react";
 import Alert from "@mui/joy/Alert";
 import Box from "@mui/joy/Box";
 import MaterialAutocomplete from "@mui/joy/Autocomplete";
@@ -31,6 +31,15 @@ export default function Autocomplete<O extends string | MenuOption<unknown>>({
     const [localInputValue, setLocalInputValue] = useState("");
     const [displayedAlertText, setDisplayedAlertText] =
         useState<ReactNode>(null);
+
+    useEffect(
+        function clearAlertText() {
+            if (!alertText && displayedAlertText) {
+                setDisplayedAlertText(null);
+            }
+        },
+        [alertText, displayedAlertText]
+    );
 
     const alert = (
         <Alert
@@ -67,9 +76,6 @@ export default function Autocomplete<O extends string | MenuOption<unknown>>({
                     );
 
                     onChange(selected || null);
-                }}
-                onChange={(_, value) => {
-                    if (value) setDisplayedAlertText(null);
                 }}
                 onBlur={() => {
                     validate();


### PR DESCRIPTION
Resolves #101 
Resolves #66 

UX improvement and a bug fix in one! Now as soon as an alert for an autocomplete form field is resolved, the alert will be cleared. Also, when you submit the game report form specifically, any alerts that were displaying before will be cleared as a result of resetting the form.