### PR TITLE
Display preselected "ladder" option for rated game type selection

### DIFF
--- a/frontend/src/GameReportForm/index.tsx
+++ b/frontend/src/GameReportForm/index.tsx
@@ -48,7 +48,7 @@ import Autocomplete from "../Autocomplete";
 import ErrorDisplay from "../ErrorDisplay";
 import FileUpload from "../FileUpload";
 import FormElement from "../FormElement";
-import MultiOptionInput from "../MultiOptionInput";
+import MultiOptionInput, { MultiOptionInputItem } from "../MultiOptionInput";
 import SelectNumericOptionInput from "../SelectNumericOptionInput";
 import SingleOptionInput from "../SingleOptionInput";
 import TextInput from "../TextInput";
@@ -261,7 +261,7 @@ function GameReportForm({
             {formData.match.value === "Rated" && (
                 <FormElement
                     label={
-                        "Optional: Was this for a specific competition? If not, leave this blank."
+                        "What kind of rated game was it? Select all that apply."
                     }
                     error={formData.competition.error}
                     hasSingleControl={false}
@@ -272,6 +272,14 @@ function GameReportForm({
                         current={formData.competition.value}
                         onChange={handleInputChange("competition")}
                         validate={validateField("competition")}
+                        fakeOptions={
+                            <MultiOptionInputItem
+                                checked
+                                value="Ladder (required)"
+                                label="Ladder (required)"
+                                onChange={() => {}}
+                            />
+                        }
                     />
                 </FormElement>
             )}

--- a/frontend/src/MultiOptionInput.tsx
+++ b/frontend/src/MultiOptionInput.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { ReactNode } from "react";
 import Checkbox from "@mui/joy/Checkbox";
 import List from "@mui/joy/List";
 import ListItem from "@mui/joy/ListItem";
@@ -6,6 +6,7 @@ import ListItem from "@mui/joy/ListItem";
 interface MultiOptionInputProps<T> {
     values: T[];
     current: T[];
+    fakeOptions?: ReactNode;
     getLabel?: (value: T) => string;
     onChange: (value: T[]) => void;
     validate: () => void;
@@ -14,6 +15,7 @@ interface MultiOptionInputProps<T> {
 export default function MultiOptionInput<T>({
     values,
     current,
+    fakeOptions,
     getLabel = String,
     onChange,
     validate,
@@ -42,19 +44,44 @@ export default function MultiOptionInput<T>({
                 "--ListItem-minHeight": "32px",
             }}
         >
+            {fakeOptions}
             {values.map((value, i) => (
-                <ListItem key={i}>
-                    <Checkbox
-                        checked={current.includes(value)}
-                        size="sm"
-                        disableIcon
-                        overlay
-                        value={String(value)}
-                        label={getLabel(value)}
-                        onChange={handleChange}
-                    />
-                </ListItem>
+                <MultiOptionInputItem
+                    key={i}
+                    checked={current.includes(value)}
+                    value={String(value)}
+                    label={getLabel(value)}
+                    onChange={handleChange}
+                />
             ))}
         </List>
+    );
+}
+
+interface MultiOptionInputItemProps {
+    checked: boolean;
+    value: string;
+    label: string;
+    onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+}
+
+export function MultiOptionInputItem({
+    checked,
+    value,
+    label,
+    onChange,
+}: MultiOptionInputItemProps) {
+    return (
+        <ListItem>
+            <Checkbox
+                checked={checked}
+                size="sm"
+                disableIcon
+                overlay
+                value={value}
+                label={label}
+                onChange={onChange}
+            />
+        </ListItem>
     );
 }


### PR DESCRIPTION
Resolves #220 I think! Displays a preselected button that says "ladder" when "rated" is chosen. The button is permanently selected, and isn't actually hooked up to state; it's purely for UX.

![image](https://github.com/user-attachments/assets/8ea140b3-7edd-4c59-ac9f-348a98ec7082)
