### PR TITLE
Refresh other pages after submitting a game report

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -185,6 +185,8 @@ export default function App() {
                                 <GameReportForm
                                     playerNames={playerNames}
                                     loadingPlayers={loadingLeaderboard}
+                                    refreshGameReports={refreshReports}
+                                    refreshLeaderboard={refreshLeaderboard}
                                 />
                             }
                         />
@@ -202,6 +204,7 @@ export default function App() {
                                     params={reportsParams}
                                     setParams={setReportsParams}
                                     refresh={refreshReports}
+                                    refreshLeaderboard={refreshLeaderboard}
                                 />
                             }
                         />

--- a/frontend/src/GameReportForm/index.tsx
+++ b/frontend/src/GameReportForm/index.tsx
@@ -61,7 +61,8 @@ interface Props {
     report?: ProcessedGameReport;
     playerNames: string[];
     loadingPlayers: boolean;
-    refreshGameReports?: () => void;
+    refreshGameReports: () => void;
+    refreshLeaderboard: () => void;
     exit?: () => void;
 }
 
@@ -69,7 +70,8 @@ function GameReportForm({
     report,
     playerNames,
     loadingPlayers,
-    refreshGameReports = () => {},
+    refreshGameReports,
+    refreshLeaderboard,
     exit,
 }: Props) {
     const initialFormData = getInitialFormData(report, report && playerNames);
@@ -102,7 +104,10 @@ function GameReportForm({
         successMessage,
     });
 
-    useConditionalActionEffect(!!successMessage, refreshGameReports);
+    useConditionalActionEffect(!!successMessage, () => {
+        refreshGameReports();
+        refreshLeaderboard();
+    });
 
     const { value: selectedExpansions } = formData.expansions;
 

--- a/frontend/src/GameReports.tsx
+++ b/frontend/src/GameReports.tsx
@@ -74,6 +74,7 @@ interface Props {
     params: GameReportParams;
     setParams: React.Dispatch<React.SetStateAction<GameReportParams>>;
     refresh: RefreshRequest;
+    refreshLeaderboard: RefreshRequest;
 }
 
 export default function GameReports({
@@ -87,6 +88,7 @@ export default function GameReports({
     params,
     setParams,
     refresh,
+    refreshLeaderboard,
 }: Props) {
     const [reportEditParams, setReportEditParams] =
         useState<ReportEditParams | null>(null);
@@ -122,6 +124,7 @@ export default function GameReports({
                                     )}
                                     loadingPlayers={loadingPlayers}
                                     refreshGameReports={refresh}
+                                    refreshLeaderboard={refreshLeaderboard}
                                     exit={() => setReportEditParams(null)}
                                 />
                             </Box>


### PR DESCRIPTION
Past Chelsea half-did this already 🎉 The existing refresh effect happens after submitting the report edit form. This expands that effect to include the rankings table, and to happen after both create + edit.

Resolves #130