### PR TITLE
Reset page to 1 when game report filters are changed

### DIFF
--- a/frontend/src/GameReports.tsx
+++ b/frontend/src/GameReports.tsx
@@ -100,7 +100,7 @@ export default function GameReports({
         setParams((params) => ({ ...params, currentPage }));
 
     const setFilters = (filters: GameReportFilters) =>
-        setParams((params) => ({ ...params, filters }));
+        setParams((params) => ({ ...params, currentPage: 1, filters }));
 
     const isPairingFilterValid = isPairingValid(filters.pairing);
 


### PR DESCRIPTION
Oops - if you add a filter **after** advancing pages and number of results is reduced such that the current page no longer exists, there appears to be zero results in the table, when in reality you're just in page limbo. This fix resets the page to 1 when a filter is changed.