### PR TITLE
Enable non-homepage refresh in development

### DIFF
--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -49,6 +49,7 @@ module.exports = {
     },
     devServer: {
         static: path.resolve(__dirname, "dist"),
+        historyApiFallback: true,
         open: true,
     },
     plugins: [


### PR DESCRIPTION
Came across code elsewhere where react router allowed a non-homepage refresh, immediately thought of us, then finally went down the config rabbit hole to find this!