### PR TITLE
Close ssh port and add SSM to ec2 role

### DIFF
--- a/infrastructure/lib/infrastructure-stack.ts
+++ b/infrastructure/lib/infrastructure-stack.ts
@@ -94,6 +94,13 @@ export class InfrastructureStack extends cdk.Stack {
         const role = new iam.Role(this, "ServerRole", {
             assumedBy: new iam.ServicePrincipal("ec2.amazonaws.com"),
         });
+
+        role.addManagedPolicy(
+            iam.ManagedPolicy.fromAwsManagedPolicyName(
+                "AmazonSSMManagedInstanceCore"
+            )
+        );
+
         writeableBuckets.forEach((bucket) => bucket.grantPut(role));
 
         const instance = new ec2.Instance(this, "ServerInstance", {
@@ -123,16 +130,6 @@ export class InfrastructureStack extends cdk.Stack {
             instanceId: instance.instanceId,
             device: "/dev/sda2",
         });
-
-        instance.connections.allowFrom(
-            ec2.Peer.ipv4("97.113.5.72/32"),
-            ec2.Port.tcp(22)
-        );
-
-        instance.connections.allowFrom(
-            ec2.Peer.ipv4("67.183.91.95/32"),
-            ec2.Port.tcp(22)
-        );
 
         instance.connections.allowFromAnyIpv4(ec2.Port.tcp(80));
         instance.connections.allowFromAnyIpv4(ec2.Port.tcp(443));


### PR DESCRIPTION
It's not a ~great practice to have an open SSH port on a host. We restrict it down to our personal IPs to minimize risk, but that's annoying because our IPs change.

AWS has a session manager that gets around this and is the "right way" to do this when using EC2.

So this change:
* Closes port 22 on the host
* Adds SSM manageability to the EC2 isntance role

There needs to be an agent running on the host to receive SSM connections, but I believe that ships by default with the amazonlinux AMI we're using.