### PR TITLE
Periodically update active player statuses

### DIFF
--- a/backend/bin/config.sh
+++ b/backend/bin/config.sh
@@ -19,3 +19,6 @@ export SERVER_SERVICE_FILE="/etc/systemd/system/${SERVICE_NAME}.service"
 export BACKUP_SCRIPT_FILE="${APP_DIR}/bin/backup_sqlite.sh"
 export BACKUP_SERVICE_FILE="/etc/systemd/system/backup-${SERVICE_NAME}.service"
 export BACKUP_TIMER_FILE="/etc/systemd/system/backup-${SERVICE_NAME}.timer"
+export ACTIVE_UPDATE_SERVICE_FILE="/etc/systemd/system/active-update-${SERVICE_NAME}.service"
+export ACTIVE_UPDATE_TIMER_FILE="/etc/systemd/system/active-update-${SERVICE_NAME}.timer"
+export ENV_FILE=/wotr-server/env

--- a/backend/bin/provision.sh
+++ b/backend/bin/provision.sh
@@ -81,7 +81,7 @@ Group=ec2-user
 Environment="PORT=8080"
 Environment="SSL_CERT_PATH=/etc/letsencrypt/live/${SERVER_HOST}/fullchain.pem"
 Environment="SSL_KEY_PATH=/etc/letsencrypt/live/${SERVER_HOST}/privkey.pem"
-EnvironmentFile=\${ENV_FILE}
+EnvironmentFile=${ENV_FILE}
 
 [Install]
 WantedBy=multi-user.target
@@ -128,7 +128,7 @@ Description=Update all player active statuses in the database
 
 [Service]
 Type=oneshot
-EnvironmentFile=\${ENV_FILE}
+EnvironmentFile=${ENV_FILE}
 ExecStart=/usr/bin/curl \
     -X POST \
     -H 'Origin: https://waroftheringcommunity.net' \

--- a/backend/bin/provision.sh
+++ b/backend/bin/provision.sh
@@ -81,6 +81,7 @@ Group=ec2-user
 Environment="PORT=8080"
 Environment="SSL_CERT_PATH=/etc/letsencrypt/live/${SERVER_HOST}/fullchain.pem"
 Environment="SSL_KEY_PATH=/etc/letsencrypt/live/${SERVER_HOST}/privkey.pem"
+EnvironmentFile=\${ENV_FILE}
 
 [Install]
 WantedBy=multi-user.target
@@ -109,7 +110,7 @@ END_UNIT
 Description=Database backup timer
 
 [Timer]
-OnCalendar=*-*-* *:00:00
+OnCalendar=hourly
 Persistent=true
 
 [Install]
@@ -119,6 +120,38 @@ END_UNIT
   echo "Staring backup service timer..."
   sudo systemctl daemon-reload
   sudo systemctl enable --now backup-${SERVICE_NAME}.timer
+
+  echo "Generating player active status update service file..."
+  cat <<END_UNIT | sudo tee $ACTIVE_UPDATE_SERVICE_FILE
+[Unit]
+Description=Update all player active statuses in the database
+
+[Service]
+Type=oneshot
+EnvironmentFile=\${ENV_FILE}
+ExecStart=/usr/bin/curl \
+    -X POST \
+    -H 'Origin: https://waroftheringcommunity.net' \
+    -H 'X-Api-Key:\${SERVICE_API_SECRET}' \
+    https://api.waroftheringcommunity.net/updateActiveStatus
+END_UNIT
+
+  echo "Generating player active status update timer file..."
+  cat <<END_UNIT | sudo tee $ACTIVE_UPDATE_TIMER_FILE
+[Unit]
+Description=Player active status update timer
+
+[Timer]
+OnCalendar=daily
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+END_UNIT
+
+  echo "Staring player active status update service timer..."
+  sudo systemctl daemon-reload
+  sudo systemctl enable --now active-update-${SERVICE_NAME}.timer
 EOF
 
 echo "Uploading database backup script..."

--- a/backend/src/Api.hs
+++ b/backend/src/Api.hs
@@ -37,7 +37,7 @@ import Types.Api
     SubmitReportRequest,
     UserInfoResponse,
   )
-import Types.Auth (SessionIdCookie)
+import Types.Auth (ServiceCaller, SessionIdCookie)
 import Types.DataField (League, LeagueTier, PlayerName)
 
 type RequiredQueryParam = QueryParam' '[Required]
@@ -91,6 +91,8 @@ type AdminAddLeaguePlayerAPI =
     :> QueryParam "playerName" PlayerName
     :> PostNoContent
 
+type UpdateActiveStatusAPI = "updateActiveStatus" :> PostNoContent
+
 type Unprotected =
   AuthGoogleLoginAPI
     :<|> SubmitReportAPI
@@ -98,6 +100,9 @@ type Unprotected =
     :<|> GetLeaderboardAPI
     :<|> GetLeagueStatsAPI
     :<|> ExportAPI
+
+type Service =
+  UpdateActiveStatusAPI
 
 type Protected =
   LogoutAPI
@@ -108,4 +113,4 @@ type Protected =
     :<|> AdminDeleteReportAPI
     :<|> AdminAddLeaguePlayerAPI
 
-type API = (AuthProtect SessionIdCookie :> Protected) :<|> Unprotected
+type API = (AuthProtect SessionIdCookie :> Protected) :<|> (AuthProtect ServiceCaller :> Service) :<|> Unprotected

--- a/backend/src/AppConfig.hs
+++ b/backend/src/AppConfig.hs
@@ -14,7 +14,8 @@ data Env = Env
     authDbPool :: SQL.ConnectionPool,
     redisPool :: Redis.Connection,
     logger :: Logger,
-    aws :: AWS.Env
+    aws :: AWS.Env,
+    apiSecret :: Maybe ByteString
   }
 
 type AppM = ReaderT Env (LoggingT Handler)

--- a/backend/src/Types/Auth.hs
+++ b/backend/src/Types/Auth.hs
@@ -4,15 +4,21 @@ import Data.Aeson (FromJSON)
 import Servant (AuthProtect)
 import Servant.Server.Experimental.Auth (AuthServerData)
 
-data SessionIdCookie = Proxy -- Type-level tag for the auth scheme
+data SessionIdCookie -- Type-level tag for auth requiring a user session cookie
 
-type instance AuthServerData (AuthProtect SessionIdCookie) = Authenticated
+type instance AuthServerData (AuthProtect SessionIdCookie) = AuthenticatedUser
+
+data ServiceCaller -- Type-level tag for auth requiring a header with our service's API secret
+
+type instance AuthServerData (AuthProtect ServiceCaller) = AuthenticatedService
 
 newtype UserId = UserId {unUserId :: Text}
 
 newtype SessionId = SessionId {unSessionId :: Text}
 
-data Authenticated = Authenticated {userId :: UserId, sessionId :: SessionId}
+data AuthenticatedUser = AuthenticatedUser {userId :: UserId, sessionId :: SessionId}
+
+data AuthenticatedService = AuthenticatedService
 
 data GoogleIdTokenClaims = GoogleIdTokenClaims
   { iss :: Text,

--- a/backend/wotr-community-website.cabal
+++ b/backend/wotr-community-website.cabal
@@ -31,7 +31,7 @@ common extensions
 
 common dependencies
     build-depends:
-        base                ^>=4.20.0.0,
+        base                ^>=4.21.0.0,
         relude              ^>=1.2.2.0,
         text                ^>=2.1.2,
         filepath            ^>=1.5.4.0,


### PR DESCRIPTION
![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExa3RpNXB6cmg2N2Rsd3FnMzAyMjdtbHg2eGFtZmd2N3Q5NjlnbWcweSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/fKYdL6Sb3gnJJyrQ7z/giphy.gif)

Resolves https://github.com/sirrus233/wotr-community-website/issues/238

This one really should've been done a while ago, but I had to build some new infrastructure to support what I wanted to do.

Before this change, we had `Authorized` and `Unauthorized` endpoints, based on whether or not the endpoint requires the user to be authenticated to call the API in question. This change introduces a third type of authorization.

`Authorized` has been renamed to `AuthorizedUser` and refers to an authorized human

`AuthorizedService` refers to a simpler auth scheme which just requires an API key in the header of the request, which can be provided by a scheduled service worker.

That will let us provide an endpoint that humans generally can't call, but our own server can use to call itself.

Having made that distinction, the rest of the change really just:
* Adds the new endpoint to update active status of users (very simple, we already have a function for this)
* Updates our provisioning script to schedule the calling of this API every day

The API key itself is stored in a file on the host, in the same persistent storage as the database.