### PR TITLE
Bug fix - league player names column missing for non-admin

### DIFF
--- a/frontend/src/Leagues.tsx
+++ b/frontend/src/Leagues.tsx
@@ -204,7 +204,7 @@ function LeagueTable({
                               </IconButton>
                           ),
                       }
-                    : undefined,
+                    : { key: "player", width: 145, content: "" },
             ].filter(isDefined)}
             colHeaders={[
                 ...FIXED_HEADERS.map(


### PR DESCRIPTION
Sorry, this is a bandaid while I figure out what's actually wrong