### PR TITLE
Adjust leagues table add-player button display logic

### DIFF
--- a/frontend/src/Leagues.tsx
+++ b/frontend/src/Leagues.tsx
@@ -188,23 +188,23 @@ function LeagueTable({
     return (
         <Table
             cornerHeaders={[
-                isAdmin
-                    ? {
-                          key: "add",
-                          width: 145,
-                          content: (
-                              <IconButton
-                                  size="sm"
-                                  disabled={loading}
-                                  onClick={openLeaguePlayerForm}
-                                  variant="solid"
-                                  color="primary"
-                              >
-                                  <AddIcon />
-                              </IconButton>
-                          ),
-                      }
-                    : { key: "player", width: 145, content: "" },
+                {
+                    key: "player",
+                    width: 145,
+                    content: isAdmin ? (
+                        <IconButton
+                            size="sm"
+                            disabled={loading}
+                            onClick={openLeaguePlayerForm}
+                            variant="solid"
+                            color="primary"
+                        >
+                            <AddIcon />
+                        </IconButton>
+                    ) : (
+                        ""
+                    ),
+                },
             ].filter(isDefined)}
             colHeaders={[
                 ...FIXED_HEADERS.map(


### PR DESCRIPTION
My first fix was almost the right one, I just panicked a little bit. In short I was accidentally removing the league table first-column header for non-admins, when I should have just been making the content of the header blank. The previous fix accomplished that, but this is a cleaner way to do it