### PR TITLE
Fix increased game log link font size

### DIFF
--- a/frontend/src/ExternalLink.tsx
+++ b/frontend/src/ExternalLink.tsx
@@ -22,7 +22,7 @@ export default function ExternalLink({
             href={href}
             target="_blank"
             rel="noopener noreferrer"
-            sx={style}
+            sx={{ fontSize: "inherit", ...style }}
         >
             <Icon sx={{ paddingRight: "5px" }} />
             {children}


### PR DESCRIPTION
The font size got out of wack with these links after the table refactor - my bad!

Old:
<img width="753" height="95" alt="image" src="https://github.com/user-attachments/assets/d6997eee-364a-4993-bc09-f1611bcda12d" />

New:
<img width="414" height="82" alt="image" src="https://github.com/user-attachments/assets/c12162e1-4c05-4a15-bd03-454526fd51bb" />
