### PR TITLE
Change game report row accents from emojis to icons

### DIFF
--- a/frontend/src/GameReports.tsx
+++ b/frontend/src/GameReports.tsx
@@ -2,10 +2,12 @@ import React, { ReactNode, useState } from "react";
 import Box from "@mui/joy/Box";
 import EditIcon from "@mui/icons-material/EditTwoTone";
 import DeleteIcon from "@mui/icons-material/DeleteTwoTone";
+import FreeIcon from "@mui/icons-material/People";
 import IconButton from "@mui/joy/IconButton";
 import Modal from "@mui/joy/Modal";
 import ModalClose from "@mui/joy/ModalClose";
 import ModalDialog from "@mui/joy/ModalDialog";
+import ShadowIcon from "@mui/icons-material/LocalFireDepartment";
 import { ErrorMessage, leagues } from "./constants";
 import useMediaQuery from "./hooks/useMediaQuery";
 import { RefreshRequest } from "./hooks/useRequestState";
@@ -205,22 +207,7 @@ export default function GameReports({
                 {
                     key: `side`,
                     style: { padding: "2px 0 2px 2px" },
-                    content: (
-                        <Box
-                            display="flex"
-                            flexDirection="column"
-                            justifyContent="center"
-                            p={0}
-                            height="100%"
-                            borderLeft={
-                                report.side === "Free"
-                                    ? `5px solid ${FREE_ACCENT_COLOR}`
-                                    : `5px solid ${SHADOW_PRIMARY_COLOR}`
-                            }
-                        >
-                            {report.side === "Free" ? "💍" : "🌋"}
-                        </Box>
-                    ),
+                    content: <GameAccent side={report.side} />,
                 },
                 isAdmin
                     ? {
@@ -479,6 +466,25 @@ function WrappedText({ children }: ContainerProps) {
     return (
         <Box width="400px" whiteSpace="wrap">
             {children}
+        </Box>
+    );
+}
+
+function GameAccent({ side }: { side: Side }) {
+    const Icon = side === "Free" ? FreeIcon : ShadowIcon;
+    const color = side === "Free" ? FREE_ACCENT_COLOR : SHADOW_PRIMARY_COLOR;
+
+    return (
+        <Box
+            display="flex"
+            flexDirection="column"
+            justifyContent="center"
+            alignItems="center"
+            p={0}
+            height="100%"
+            borderLeft={`5px solid ${color}`}
+        >
+            <Icon sx={{ width: "20px", height: "20px", color }} />
         </Box>
     );
 }


### PR DESCRIPTION
Resolves #129

Material UI doesn't have too much to work with for representing FP - no ring, no sword ☹️ I didn't want to pull from the game's actual iconography to avoid potential copyright issues. How do you feel about these choices?

<img width="726" height="241" alt="image" src="https://github.com/user-attachments/assets/3e590f77-99f7-4875-bd47-cf7b9536c2ce" />
