### PR TITLE
Fix relatively positioned elements floating above table headers

### DIFF
--- a/frontend/src/Table/index.tsx
+++ b/frontend/src/Table/index.tsx
@@ -49,6 +49,7 @@ const Container = styled("table")<{ ownerState: ContainerProps }>(
 const TableHeader = styled("th")({
     overflow: "hidden",
     padding: CELL_PADDING,
+    zIndex: 1,
 });
 
 const ColHeader = styled(TableHeader)({


### PR DESCRIPTION
Another one 🤦‍♀️ 

#### Current:

<img width="284" height="194" alt="image" src="https://github.com/user-attachments/assets/e80a981c-4ddf-49c5-a4f2-36b4168b4c8c" />

#### Fixed:

<img width="328" height="172" alt="image" src="https://github.com/user-attachments/assets/99f92e45-3158-406b-a2ab-99636a1f687f" />
