### PR TITLE
Support frontend inequality filtering and add turns filter

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -114,6 +114,7 @@ export default function App() {
                 winners: [],
                 losers: [],
                 leagues: [],
+                turns: null,
             },
         },
         sendRequest: (params) => {

--- a/frontend/src/GameReports.tsx
+++ b/frontend/src/GameReports.tsx
@@ -143,7 +143,7 @@ export default function GameReports({
                 filterType: "inequality",
                 placeholder: "Turn",
                 min: 1,
-                max: 50,
+                max: 999,
                 current: filters.turns,
                 appliedCount: isDefined(filters.turns?.[1]) ? 1 : 0,
                 onChange: (value) => setFilters({ ...filters, turns: value }),

--- a/frontend/src/GameReports.tsx
+++ b/frontend/src/GameReports.tsx
@@ -119,10 +119,10 @@ export default function GameReports({
             key: "Pairing",
             width: PAIRING_COL_WIDTH,
             filter: {
+                filterType: "autocomplete",
                 placeholder: "Select pairing",
                 loading: loadingPlayers,
                 options: playerOptions,
-                width: PAIRING_COL_WIDTH,
                 current: filters.pairing,
                 appliedCount: isPairingFilterValid ? filters.pairing.length : 0,
                 onChange: (values: MenuOption<number>[]) =>
@@ -136,14 +136,27 @@ export default function GameReports({
 
     const colHeaders: ColHeaderData[] = [
         { key: "Timestamp" },
-        { key: "Turn" },
+        {
+            key: "Turn",
+            width: 120,
+            filter: {
+                filterType: "inequality",
+                placeholder: "Turn",
+                min: 1,
+                max: 50,
+                current: filters.turns,
+                appliedCount: isDefined(filters.turns?.[1]) ? 1 : 0,
+                onChange: (value) => setFilters({ ...filters, turns: value }),
+            },
+        },
         {
             key: "Winner",
+            width: PLAYER_COL_WIDTH,
             filter: {
+                filterType: "autocomplete",
                 placeholder: "Select winner",
                 loading: loadingPlayers,
                 options: playerOptions,
-                width: PLAYER_COL_WIDTH,
                 current: filters.winners,
                 appliedCount: filters.winners.length,
                 onChange: (values: MenuOption<number>[]) =>
@@ -152,11 +165,12 @@ export default function GameReports({
         },
         {
             key: "Loser",
+            width: PLAYER_COL_WIDTH,
             filter: {
+                filterType: "autocomplete",
                 placeholder: "Select loser",
                 loading: loadingPlayers,
                 options: playerOptions,
-                width: PLAYER_COL_WIDTH,
                 current: filters.losers,
                 appliedCount: filters.losers.length,
                 onChange: (values: MenuOption<number>[]) =>
@@ -168,7 +182,9 @@ export default function GameReports({
         { key: "Competition Type" },
         {
             key: "League",
+            width: LEAGUE_COL_WIDTH,
             filter: {
+                filterType: "autocomplete",
                 placeholder: "Select leagues",
                 loading: false,
                 allOption: { id: ALL_OPTION_ID, label: "Any league" },
@@ -177,7 +193,6 @@ export default function GameReports({
                     id: league,
                     label: getLeagueLabel(league),
                 })),
-                width: LEAGUE_COL_WIDTH,
                 current: filters.leagues,
                 appliedCount: filters.leagues.length,
                 onChange: (values: MenuOption<string>[]) => {
@@ -436,6 +451,7 @@ export function serializeReportsParams(params: GameReportParams) {
         limit: params.limit,
         offset: getReportsOffset(params.currentPage, params.limit),
         filter: JSON.stringify({
+            ...params.filters,
             pairing: pairing?.length === 1 ? [...pairing, null] : pairing,
             winners: toFilterParam(params.filters.winners),
             losers: toFilterParam(params.filters.losers),

--- a/frontend/src/Table/AutocompleteFilter.tsx
+++ b/frontend/src/Table/AutocompleteFilter.tsx
@@ -3,27 +3,10 @@ import MaterialAutocomplete from "@mui/joy/Autocomplete";
 import Box from "@mui/joy/Box";
 import FormControl from "@mui/joy/FormControl";
 import FormHelperText from "@mui/joy/FormHelperText";
-import { ErrorMessage } from "../constants";
-import { MenuOption } from "../types";
+import { FILTER_ERROR_HEIGHT, TABLE_FILTER_HEIGHT } from "./constants";
+import { AutocompleteProps, Option } from "./types";
 
-export const TABLE_FILTER_HEIGHT = "2em";
-export const FILTER_ERROR_HEIGHT = "1.5em";
-
-type Option = string | MenuOption<unknown>;
-
-export interface TableFilterProps<O extends Option> {
-    options: O[];
-    current: O[];
-    placeholder: string;
-    loading: boolean;
-    width: number;
-    errorMessage?: ErrorMessage;
-    allOption?: O;
-    emptyOption?: O;
-    onChange: (value: O[]) => void;
-}
-
-export default function TableFilter<O extends Option>({
+export default function AutocompleteFilter<O extends Option>({
     options,
     current,
     placeholder,
@@ -33,7 +16,7 @@ export default function TableFilter<O extends Option>({
     allOption,
     emptyOption,
     onChange,
-}: TableFilterProps<O>) {
+}: AutocompleteProps<O> & { width: number }) {
     const [isFocused, setIsFocused] = useState(false);
 
     const paddedWidth = `calc(${width}px - 10px)`;

--- a/frontend/src/Table/FilterBar.tsx
+++ b/frontend/src/Table/FilterBar.tsx
@@ -4,7 +4,8 @@ import ExpandIcon from "@mui/icons-material/KeyboardArrowUp";
 import FilterIconAlt from "@mui/icons-material/FilterAlt";
 import IconButton from "@mui/joy/IconButton";
 import { styled } from "@mui/joy/styles";
-import TableFilter from "./TableFilter";
+import AutocompleteFilter from "./AutocompleteFilter";
+import InequalityFilter from "./InequalityFilter";
 import sumPriorWidths from "./sumPriorWidths";
 import { MenuOption } from "../types";
 import { ColHeaderData, CornerHeaderData } from "./types";
@@ -67,18 +68,16 @@ export default function FilterBar<
                                 expanded={areFiltersOpen}
                                 setExpanded={setAreFiltersOpen}
                             />
-                        ) : filter ? (
-                            <TableFilter width={width} {...filter} />
                         ) : (
-                            <></>
+                            <Filter filter={filter} width={width} />
                         )}
                     </CornerFilterSlot>
                 );
             })}
 
-            {colHeaders.map(({ key, filter, style = {} }) => (
+            {colHeaders.map(({ key, filter, width = 0, style = {} }) => (
                 <ColumnFilterSlot key={key} sx={style}>
-                    {filter ? <TableFilter {...filter} /> : <></>}
+                    <Filter filter={filter} width={width} />
                 </ColumnFilterSlot>
             ))}
         </Container>
@@ -106,4 +105,20 @@ export function ExpandButton({ expanded, setExpanded }: ExpandButtonProps) {
             {expanded ? <CollapseIcon /> : <ExpandIcon />}
         </IconButton>
     );
+}
+
+interface HeaderWithFilterProps {
+    filter?: ColHeaderData["filter"] | CornerHeaderData["filter"];
+    width: number;
+}
+
+export function Filter({ filter, width }: HeaderWithFilterProps): JSX.Element {
+    switch (filter?.filterType) {
+        case "autocomplete":
+            return <AutocompleteFilter width={width} {...filter} />;
+        case "inequality":
+            return <InequalityFilter width={width} {...filter} />;
+        case undefined:
+            return <></>;
+    }
 }

--- a/frontend/src/Table/InequalityFilter.tsx
+++ b/frontend/src/Table/InequalityFilter.tsx
@@ -1,0 +1,123 @@
+import React, { useEffect, useState } from "react";
+import Box from "@mui/joy/Box";
+import ClearIcon from "@mui/icons-material/CloseRounded";
+import IconButton from "@mui/joy/IconButton";
+import Option from "@mui/joy/Option";
+import Select from "@mui/joy/Select";
+import { InequalityFilter, InequalityOperator } from "../types";
+import { isDefined, range } from "../utils";
+import { TABLE_FILTER_HEIGHT } from "./constants";
+import { InequalityFilterProps } from "./types";
+
+export default function InequalityFilter({
+    current,
+    min,
+    max,
+    placeholder,
+    width,
+    onChange,
+}: InequalityFilterProps & { width: number }) {
+    const [currentOperator, currentValue = null] = current || [];
+
+    const [inputValue, setInputValue] = useState<number | null>(currentValue);
+    const [inputOperator, setInputOperator] = useState<InequalityOperator>(
+        currentOperator || "EQ"
+    );
+
+    useEffect(() => {
+        const didValueChange = currentValue !== inputValue;
+        const didOperatorChange = currentOperator !== inputOperator;
+
+        if (didValueChange) {
+            onChange(
+                isDefined(inputValue) ? [inputOperator, inputValue] : null
+            );
+        } else if (didOperatorChange && isDefined(inputValue)) {
+            onChange([inputOperator, inputValue]);
+        }
+    }, [currentOperator, currentValue, inputOperator, inputValue]);
+
+    const commonStyle = {
+        background: "white",
+        fontSize: "inherit",
+        height: TABLE_FILTER_HEIGHT,
+        maxHeight: "100%",
+        minWidth: 0,
+        minHeight: 0,
+        lineHeight: 0,
+    };
+
+    return (
+        <Box
+            display="flex"
+            alignItems="end"
+            justifyContent="center"
+            height="100%"
+            maxWidth={width}
+        >
+            <Select
+                size="sm"
+                value={inputOperator}
+                onChange={(_, o) => setInputOperator(o || "EQ")}
+                sx={{
+                    ...commonStyle,
+                    width: "fit-content",
+                    pl: "4px",
+                    mr: "1px",
+                }}
+            >
+                {(["EQ", "GT", "LT"] as const).map((o) => (
+                    <Option key={o} value={o}>
+                        {operatorLabel(o)}
+                    </Option>
+                ))}
+            </Select>
+
+            <Select
+                size="sm"
+                placeholder={placeholder}
+                value={inputValue}
+                onChange={(_, value) => setInputValue(value)}
+                indicator={isDefined(inputValue) ? null : undefined}
+                sx={{ ...commonStyle, flex: 1 }}
+                endDecorator={
+                    isDefined(inputValue) ? (
+                        <ResetButton reset={() => setInputValue(null)} />
+                    ) : undefined
+                }
+            >
+                {range(min, max + 1).map((value) => (
+                    <Option key={value} value={value}>
+                        {value}
+                    </Option>
+                ))}
+            </Select>
+        </Box>
+    );
+}
+
+function ResetButton(props: { reset: () => void }) {
+    const { reset } = props;
+
+    return (
+        <IconButton
+            size="sm"
+            onMouseDown={(e) => e.stopPropagation()}
+            onClick={reset}
+            sx={{ minWidth: 0, minHeight: 0, lineHeight: 0, p: "1px" }}
+        >
+            <ClearIcon />
+        </IconButton>
+    );
+}
+
+function operatorLabel(operator: InequalityOperator) {
+    switch (operator) {
+        case "EQ":
+            return "=";
+        case "GT":
+            return ">";
+        case "LT":
+            return "<";
+    }
+}

--- a/frontend/src/Table/InequalityFilter.tsx
+++ b/frontend/src/Table/InequalityFilter.tsx
@@ -2,10 +2,11 @@ import React, { useEffect, useState } from "react";
 import Box from "@mui/joy/Box";
 import ClearIcon from "@mui/icons-material/CloseRounded";
 import IconButton from "@mui/joy/IconButton";
+import Input from "@mui/joy/Input";
 import Option from "@mui/joy/Option";
 import Select from "@mui/joy/Select";
 import { InequalityFilter, InequalityOperator } from "../types";
-import { isDefined, range } from "../utils";
+import { isDefined, noNansense } from "../utils";
 import { TABLE_FILTER_HEIGHT } from "./constants";
 import { InequalityFilterProps } from "./types";
 
@@ -78,25 +79,24 @@ export default function InequalityFilter({
                 ))}
             </Select>
 
-            <Select
+            <Input
                 size="sm"
+                type="number"
                 placeholder={placeholder}
-                value={inputValue}
-                onChange={(_, value) => setInputValue(value)}
-                indicator={isDefined(inputValue) ? null : undefined}
+                value={inputValue === null ? "" : String(inputValue)}
+                onChange={(e) =>
+                    setInputValue(
+                        constrainNumberInput(e.target.value, min, max)
+                    )
+                }
                 sx={{ ...commonStyle, flex: 1 }}
+                slotProps={{ input: { min, max } }}
                 endDecorator={
                     isDefined(inputValue) ? (
                         <ResetButton reset={() => setInputValue(null)} />
                     ) : undefined
                 }
-            >
-                {range(min, max + 1).map((value) => (
-                    <Option key={value} value={value}>
-                        {value}
-                    </Option>
-                ))}
-            </Select>
+            />
         </Box>
     );
 }
@@ -145,4 +145,16 @@ function translateFilter(
         default:
             return [operator, value];
     }
+}
+
+function constrainNumberInput(
+    value: string,
+    min?: number,
+    max?: number
+): number | null {
+    if (value === "") return null;
+    const num = noNansense(Number(value));
+    if (isDefined(min) && num < min) return min;
+    if (isDefined(max) && num > max) return max;
+    return num;
 }

--- a/frontend/src/Table/InequalityFilter.tsx
+++ b/frontend/src/Table/InequalityFilter.tsx
@@ -70,7 +70,7 @@ export default function InequalityFilter({
                     mr: "1px",
                 }}
             >
-                {(["EQ", "GT", "LT", "GTE", "LTE"] as const).map((o) => (
+                {(["EQ", "GT", "GTE", "LT", "LTE"] as const).map((o) => (
                     <Option key={o} value={o}>
                         {operatorLabel(o)}
                     </Option>

--- a/frontend/src/Table/InequalityFilter.tsx
+++ b/frontend/src/Table/InequalityFilter.tsx
@@ -10,8 +10,6 @@ import { isDefined, noNansense } from "../utils";
 import { TABLE_FILTER_HEIGHT } from "./constants";
 import { InequalityFilterProps } from "./types";
 
-type PseudoInequalityOperator = "GTE" | "LTE";
-
 export default function InequalityFilter({
     current,
     min,
@@ -23,9 +21,9 @@ export default function InequalityFilter({
     const [currentOperator, currentValue = null] = current || [];
 
     const [inputValue, setInputValue] = useState<number | null>(currentValue);
-    const [inputOperator, setInputOperator] = useState<
-        InequalityOperator | PseudoInequalityOperator
-    >(currentOperator || "EQ");
+    const [inputOperator, setInputOperator] = useState<InequalityOperator>(
+        currentOperator || "EQ"
+    );
 
     useEffect(() => {
         const didValueChange = currentValue !== inputValue;
@@ -116,9 +114,7 @@ function ResetButton(props: { reset: () => void }) {
     );
 }
 
-function operatorLabel(
-    operator: InequalityOperator | PseudoInequalityOperator
-): string {
+function operatorLabel(operator: InequalityOperator): string {
     switch (operator) {
         case "EQ":
             return "=";
@@ -134,9 +130,9 @@ function operatorLabel(
 }
 
 function translateFilter(
-    operator: InequalityOperator | PseudoInequalityOperator,
+    operator: InequalityOperator,
     value: number
-): [InequalityOperator, number] {
+): InequalityFilter {
     switch (operator) {
         case "GTE":
             return ["GT", value - 1];

--- a/frontend/src/Table/InequalityFilter.tsx
+++ b/frontend/src/Table/InequalityFilter.tsx
@@ -58,6 +58,7 @@ export default function InequalityFilter({
             justifyContent="center"
             height="100%"
             maxWidth={width}
+            sx={{ "&&": { "*": { margin: 0, marginInline: 0 } } }}
         >
             <Select
                 size="sm"
@@ -66,7 +67,7 @@ export default function InequalityFilter({
                 sx={{
                     ...commonStyle,
                     width: "fit-content",
-                    pl: "4px",
+                    px: "4px",
                     mr: "1px",
                 }}
             >

--- a/frontend/src/Table/constants.tsx
+++ b/frontend/src/Table/constants.tsx
@@ -1,0 +1,2 @@
+export const TABLE_FILTER_HEIGHT = "2em";
+export const FILTER_ERROR_HEIGHT = "1.5em";

--- a/frontend/src/Table/index.tsx
+++ b/frontend/src/Table/index.tsx
@@ -4,7 +4,7 @@ import FilterIcon from "@mui/icons-material/FilterList";
 import IconButton from "@mui/joy/IconButton";
 import { styled } from "@mui/joy/styles";
 import FilterBar, { ExpandButton, PINNED_COLS_Z_IDX } from "./FilterBar";
-import { FILTER_ERROR_HEIGHT, TABLE_FILTER_HEIGHT } from "./TableFilter";
+import { FILTER_ERROR_HEIGHT, TABLE_FILTER_HEIGHT } from "./constants";
 import {
     TABLE_BORDER_COLOR,
     TABLE_FONT_COLOR,
@@ -160,14 +160,14 @@ export default function Table<
                     )}
 
                     {colHeaders.map(
-                        ({ key, content, span, filter, style = {} }) => (
+                        ({ key, content, span, filter, width, style = {} }) => (
                             <ColHeader
                                 scope="col"
                                 key={key}
                                 colSpan={span}
                                 sx={{
-                                    width: filter?.width,
-                                    minWidth: filter?.width,
+                                    width,
+                                    minWidth: width,
                                     top: areFiltersOpen ? filterBarHeight : 0,
                                     ...style,
                                 }}

--- a/frontend/src/Table/index.tsx
+++ b/frontend/src/Table/index.tsx
@@ -105,6 +105,7 @@ export default function Table<
     return (
         <Container
             sx={style}
+            cellPadding={0}
             ownerState={{ pinnedColCount: cornerHeaders.length }}
         >
             <thead>
@@ -167,6 +168,7 @@ export default function Table<
                                 colSpan={span}
                                 sx={{
                                     width,
+                                    maxWidth: width,
                                     minWidth: width,
                                     top: areFiltersOpen ? filterBarHeight : 0,
                                     ...style,

--- a/frontend/src/Table/types.tsx
+++ b/frontend/src/Table/types.tsx
@@ -11,14 +11,15 @@ interface CommonFilterProps {
     appliedCount: number;
 }
 
-export interface AutocompleteProps<O extends Option> extends CommonFilterProps {
+export interface AutocompleteProps<Opt extends Option>
+    extends CommonFilterProps {
     filterType: "autocomplete";
-    options: O[];
-    current: O[];
+    options: Opt[];
+    current: Opt[];
     loading: boolean;
-    allOption?: O;
-    emptyOption?: O;
-    onChange: (value: O[]) => void;
+    allOption?: Opt;
+    emptyOption?: Opt;
+    onChange: (value: Opt[]) => void;
 }
 
 export interface InequalityFilterProps extends CommonFilterProps {

--- a/frontend/src/Table/types.tsx
+++ b/frontend/src/Table/types.tsx
@@ -40,6 +40,7 @@ interface CommonColHeaderData {
     span?: number;
     style?: CSSProperties;
 }
+
 interface ColHeaderDataA extends CommonColHeaderData {
     filter?: never;
     width?: number;

--- a/frontend/src/Table/types.tsx
+++ b/frontend/src/Table/types.tsx
@@ -25,8 +25,8 @@ export interface AutocompleteProps<Opt extends Option>
 export interface InequalityFilterProps extends CommonFilterProps {
     filterType: "inequality";
     current: InequalityFilter | null;
-    min: number;
-    max: number;
+    min?: number;
+    max?: number;
     onChange: (value: [InequalityOperator, number] | null) => void;
 }
 

--- a/frontend/src/Table/types.tsx
+++ b/frontend/src/Table/types.tsx
@@ -1,14 +1,58 @@
 import { CSSProperties, ReactNode } from "react";
-import { TableFilterProps } from "./TableFilter";
-import { MenuOption } from "../types";
+import { ErrorMessage } from "../constants";
+import { InequalityFilter, InequalityOperator, MenuOption } from "../types";
 
-export interface ColHeaderData<T extends MenuOption<any> = MenuOption<any>> {
+export type Option = string | MenuOption<unknown>;
+
+interface CommonFilterProps {
+    filterType: "autocomplete" | "inequality";
+    placeholder: string;
+    errorMessage?: ErrorMessage;
+    appliedCount: number;
+}
+
+export interface AutocompleteProps<O extends Option> extends CommonFilterProps {
+    filterType: "autocomplete";
+    options: O[];
+    current: O[];
+    loading: boolean;
+    allOption?: O;
+    emptyOption?: O;
+    onChange: (value: O[]) => void;
+}
+
+export interface InequalityFilterProps extends CommonFilterProps {
+    filterType: "inequality";
+    current: InequalityFilter | null;
+    min: number;
+    max: number;
+    onChange: (value: [InequalityOperator, number] | null) => void;
+}
+
+type Filter<T extends MenuOption<any> = MenuOption<any>> =
+    | AutocompleteProps<T>
+    | InequalityFilterProps;
+
+interface CommonColHeaderData {
     key: string | number;
     content?: ReactNode;
-    filter?: TableFilterProps<T> & { width: number; appliedCount: number };
     span?: number;
     style?: CSSProperties;
 }
+interface ColHeaderDataA extends CommonColHeaderData {
+    filter?: never;
+    width?: number;
+}
+
+interface ColHeaderDataB<T extends MenuOption<any> = MenuOption<any>>
+    extends CommonColHeaderData {
+    filter: Filter<T>;
+    width: number;
+}
+
+export type ColHeaderData<T extends MenuOption<any> = MenuOption<any>> =
+    | ColHeaderDataA
+    | ColHeaderDataB<T>;
 
 export interface RowHeaderData {
     key: string | number;
@@ -34,7 +78,7 @@ export interface CornerHeaderData<T extends MenuOption<any> = MenuOption<any>> {
     key: string | number;
     content?: ReactNode;
     width: number;
-    filter?: Omit<TableFilterProps<T>, "width"> & { appliedCount: number };
+    filter?: Filter<T>;
     span?: number;
     style?: CSSProperties;
 }

--- a/frontend/src/Table/types.tsx
+++ b/frontend/src/Table/types.tsx
@@ -1,6 +1,6 @@
 import { CSSProperties, ReactNode } from "react";
 import { ErrorMessage } from "../constants";
-import { InequalityFilter, InequalityOperator, MenuOption } from "../types";
+import { InequalityFilter, MenuOption } from "../types";
 
 export type Option = string | MenuOption<unknown>;
 
@@ -27,7 +27,7 @@ export interface InequalityFilterProps extends CommonFilterProps {
     current: InequalityFilter | null;
     min?: number;
     max?: number;
-    onChange: (value: [InequalityOperator, number] | null) => void;
+    onChange: (value: InequalityFilter | null) => void;
 }
 
 type Filter<T extends MenuOption<any> = MenuOption<any>> =

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -247,12 +247,17 @@ export type ValidLeaguePlayerFormData = {
 
 export type ValueOf<T> = T[keyof T];
 
+export type InequalityOperator = "GT" | "LT" | "EQ";
+
+export type InequalityFilter = [InequalityOperator, number];
+
 export type GameReportFilters = {
     pairing: MenuOption<number>[];
     players: MenuOption<number>[];
     winners: MenuOption<number>[];
     losers: MenuOption<number>[];
     leagues: MenuOption<string>[];
+    turns: InequalityFilter | null;
 };
 
 export type GameReportParams = {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -247,9 +247,15 @@ export type ValidLeaguePlayerFormData = {
 
 export type ValueOf<T> = T[keyof T];
 
-export type InequalityOperator = "GT" | "LT" | "EQ";
+export type ApiInequalityOperator = "GT" | "LT" | "EQ";
 
-export type InequalityFilter = [InequalityOperator, number];
+export type NonApiInequalityOperator = "GTE" | "LTE";
+
+export type InequalityOperator =
+    | ApiInequalityOperator
+    | NonApiInequalityOperator;
+
+export type InequalityFilter = [ApiInequalityOperator, number];
 
 export type GameReportFilters = {
     pairing: MenuOption<number>[];


### PR DESCRIPTION
First frontend filter to go with your backend work 🎉 

This PR establishes a new UI component for inequality filtering, uses that new filter for the `turns` column, and refines types to make them smarter at telling what properties are allowed/needed based on context.

This is branched from a rebased version of your [filters](https://github.com/sirrus233/wotr-community-website/tree/filters) branch. Should we just merge yours even though it hasn't been fully tested so we don't get into a feature branch situation? I did quick regression checks of the existing filters and everything seems A-OK so far.

| Closed | Operator open | Turn open | Filter applied
| - | - | - | - |
| <img width="556" height="186" alt="image" src="https://github.com/user-attachments/assets/c109a3dc-6223-431d-ae6a-9f81fa075694" /> | <img width="295" height="167" alt="image" src="https://github.com/user-attachments/assets/42a196ec-440f-45d9-8875-a7cdf6b4e377" /> | <img width="269" height="411" alt="image" src="https://github.com/user-attachments/assets/73b6b299-deb5-4af1-a326-48820d589ea4" />| <img width="321" height="162" alt="image" src="https://github.com/user-attachments/assets/965b3608-0b4f-4ad9-b7d7-1fc50e159d69" /> |

I went with a `Select` instead of an `Input` or `Autocomplete` for the turn input because I personally found scrolling and selecting to be an okay UX for our number columns with limited ceilings, but that might be a controversial choice 😬 I can adjust it if desired!