### PR TITLE
Support frontend boolean filtering and add game log filter

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -120,6 +120,7 @@ export default function App() {
                 corruption: null,
                 initialEyes: null,
                 interestRating: null,
+                hasLog: null,
             },
         },
         sendRequest: (params) => {

--- a/frontend/src/GameReports.tsx
+++ b/frontend/src/GameReports.tsx
@@ -278,7 +278,19 @@ export default function GameReports({
             },
         },
         { key: "Comments" },
-        { key: "Game Log" },
+        {
+            key: "Game Log",
+            width: 150,
+            filter: {
+                filterType: "boolean",
+                placeholder: "Select",
+                current: filters.hasLog,
+                trueLabel: "Log",
+                falseLabel: "No log",
+                appliedCount: isDefined(filters.hasLog) ? 1 : 0,
+                onChange: (hasLog) => setFilters({ ...filters, hasLog }),
+            },
+        },
     ];
 
     const rows = reports.map(

--- a/frontend/src/Table/AutocompleteFilter.tsx
+++ b/frontend/src/Table/AutocompleteFilter.tsx
@@ -4,6 +4,7 @@ import Box from "@mui/joy/Box";
 import FormControl from "@mui/joy/FormControl";
 import FormHelperText from "@mui/joy/FormHelperText";
 import { FILTER_ERROR_HEIGHT, TABLE_FILTER_HEIGHT } from "./constants";
+import { FilterContainer } from "./styledComponents";
 import { AutocompleteProps, Option } from "./types";
 
 export default function AutocompleteFilter<O extends Option>({
@@ -50,12 +51,12 @@ export default function AutocompleteFilter<O extends Option>({
     }
 
     return (
-        <Box
-            display="flex"
-            flexDirection="column"
-            alignItems="center"
-            justifyContent="end"
-            height="100%"
+        <FilterContainer
+            sx={{
+                flexDirection: "column",
+                alignItems: "center",
+                justifyContent: "end",
+            }}
         >
             <FormControl error={!!errorMessage}>
                 {errorMessage && (
@@ -124,7 +125,7 @@ export default function AutocompleteFilter<O extends Option>({
                     />
                 </Box>
             </FormControl>
-        </Box>
+        </FilterContainer>
     );
 }
 

--- a/frontend/src/Table/BooleanFilter.tsx
+++ b/frontend/src/Table/BooleanFilter.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import Option from "@mui/joy/Option";
+import Select from "@mui/joy/Select";
+import { isDefined } from "../utils";
+import { TABLE_FILTER_HEIGHT } from "./constants";
+import ResetButton from "./ResetButton";
+import { FilterContainer } from "./styledComponents";
+import { BooleanFilterProps } from "./types";
+
+export default function BooleanFilter({
+    current,
+    placeholder,
+    width,
+    trueLabel,
+    falseLabel,
+    onChange,
+}: BooleanFilterProps & { width: number }) {
+    return (
+        <FilterContainer sx={{ width, minWidth: width, maxWidth: width }}>
+            <Select
+                size="sm"
+                placeholder={placeholder}
+                renderValue={(o) => o?.label}
+                value={current}
+                onChange={(_, value) => onChange(value)}
+                endDecorator={
+                    isDefined(current) ? (
+                        <ResetButton reset={() => onChange(null)} />
+                    ) : undefined
+                }
+                sx={{
+                    boxSizing: "border-box",
+                    height: TABLE_FILTER_HEIGHT,
+                    minHeight: 0,
+                    maxHeight: "100%",
+                    width: "100%",
+                    minWidth: 0,
+                    background: "white",
+                    fontSize: "inherit",
+                }}
+            >
+                {[true, false].map((option) => (
+                    <Option key={String(option)} value={option}>
+                        {option ? trueLabel : falseLabel}
+                    </Option>
+                ))}
+            </Select>
+        </FilterContainer>
+    );
+}

--- a/frontend/src/Table/FilterBar.tsx
+++ b/frontend/src/Table/FilterBar.tsx
@@ -5,6 +5,7 @@ import FilterIconAlt from "@mui/icons-material/FilterAlt";
 import IconButton from "@mui/joy/IconButton";
 import { styled } from "@mui/joy/styles";
 import AutocompleteFilter from "./AutocompleteFilter";
+import BooleanFilter from "./BooleanFilter";
 import InequalityFilter from "./InequalityFilter";
 import sumPriorWidths from "./sumPriorWidths";
 import { MenuOption } from "../types";
@@ -118,6 +119,8 @@ export function Filter({ filter, width }: HeaderWithFilterProps): JSX.Element {
             return <AutocompleteFilter width={width} {...filter} />;
         case "inequality":
             return <InequalityFilter width={width} {...filter} />;
+        case "boolean":
+            return <BooleanFilter width={width} {...filter} />;
         case undefined:
             return <></>;
     }

--- a/frontend/src/Table/InequalityFilter.tsx
+++ b/frontend/src/Table/InequalityFilter.tsx
@@ -1,13 +1,12 @@
 import React, { useEffect, useState } from "react";
-import Box from "@mui/joy/Box";
-import ClearIcon from "@mui/icons-material/CloseRounded";
-import IconButton from "@mui/joy/IconButton";
 import Input from "@mui/joy/Input";
 import Option from "@mui/joy/Option";
 import Select from "@mui/joy/Select";
 import { InequalityFilter, InequalityOperator } from "../types";
 import { isDefined, noNansense } from "../utils";
 import { TABLE_FILTER_HEIGHT } from "./constants";
+import ResetButton from "./ResetButton";
+import { FilterContainer } from "./styledComponents";
 import { InequalityFilterProps } from "./types";
 
 export default function InequalityFilter({
@@ -51,13 +50,11 @@ export default function InequalityFilter({
     };
 
     return (
-        <Box
-            display="flex"
-            alignItems="end"
-            justifyContent="center"
-            height="100%"
-            maxWidth={width}
-            sx={{ "&&": { "*": { margin: 0, marginInline: 0 } }, mx: "5px" }}
+        <FilterContainer
+            sx={{
+                maxWidth: width,
+                "&&": { "*": { margin: 0, marginInline: 0 } },
+            }}
         >
             <Select
                 size="sm"
@@ -95,22 +92,7 @@ export default function InequalityFilter({
                     ) : undefined
                 }
             />
-        </Box>
-    );
-}
-
-function ResetButton(props: { reset: () => void }) {
-    const { reset } = props;
-
-    return (
-        <IconButton
-            size="sm"
-            onMouseDown={(e) => e.stopPropagation()}
-            onClick={reset}
-            sx={{ minWidth: 0, minHeight: 0, lineHeight: 0, p: "1px" }}
-        >
-            <ClearIcon />
-        </IconButton>
+        </FilterContainer>
     );
 }
 

--- a/frontend/src/Table/ResetButton.tsx
+++ b/frontend/src/Table/ResetButton.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import ClearIcon from "@mui/icons-material/CloseRounded";
+import IconButton from "@mui/joy/IconButton";
+
+interface Props {
+    reset: () => void;
+}
+
+export default function ResetButton({ reset }: Props) {
+    return (
+        <IconButton
+            size="sm"
+            onMouseDown={(e) => e.stopPropagation()}
+            onClick={reset}
+            sx={{ minWidth: 0, minHeight: 0, lineHeight: 0, p: "1px" }}
+        >
+            <ClearIcon />
+        </IconButton>
+    );
+}

--- a/frontend/src/Table/styledComponents.tsx
+++ b/frontend/src/Table/styledComponents.tsx
@@ -1,0 +1,12 @@
+import { styled } from "@mui/joy/styles";
+
+export const FilterContainer = styled("div")({
+    boxSizing: "border-box",
+    display: "flex",
+    alignItems: "end",
+    justifyContent: "center",
+    height: "100%",
+    padding: "0 5px",
+    fontWeight: "normal",
+    lineHeight: "1em",
+});

--- a/frontend/src/Table/types.tsx
+++ b/frontend/src/Table/types.tsx
@@ -5,7 +5,7 @@ import { InequalityFilter, MenuOption } from "../types";
 export type Option = string | MenuOption<unknown>;
 
 interface CommonFilterProps {
-    filterType: "autocomplete" | "inequality";
+    filterType: "autocomplete" | "inequality" | "boolean";
     placeholder: string;
     errorMessage?: ErrorMessage;
     appliedCount: number;
@@ -30,9 +30,18 @@ export interface InequalityFilterProps extends CommonFilterProps {
     onChange: (value: InequalityFilter | null) => void;
 }
 
+export interface BooleanFilterProps extends CommonFilterProps {
+    filterType: "boolean";
+    current: boolean | null;
+    trueLabel: string;
+    falseLabel: string;
+    onChange: (value: boolean | null) => void;
+}
+
 type Filter<T extends MenuOption<any> = MenuOption<any>> =
     | AutocompleteProps<T>
-    | InequalityFilterProps;
+    | InequalityFilterProps
+    | BooleanFilterProps;
 
 interface CommonColHeaderData {
     key: string | number;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -269,6 +269,7 @@ export type GameReportFilters = {
     corruption: InequalityFilter | null;
     initialEyes: InequalityFilter | null;
     interestRating: InequalityFilter | null;
+    hasLog: boolean | null;
 };
 
 export type GameReportParams = {


### PR DESCRIPTION
Game log column filter, underpinned by a `BooleanFilter` component which can be reused for the comments and treebeard columns.

| Initial | Menu open | "No log" selected | "Log" selected |
| - | - | - | - |
| <img width="159" height="79" alt="image" src="https://github.com/user-attachments/assets/5a9f645e-223c-4082-8738-60b45dc7d0aa" /> | <img width="171" height="140" alt="image" src="https://github.com/user-attachments/assets/863f82d5-eb84-4ecd-9243-395763efc8c1" /> | <img width="157" height="75" alt="image" src="https://github.com/user-attachments/assets/cc67e071-b545-4178-9394-e22b3fbd164d" /> | <img width="158" height="72" alt="image" src="https://github.com/user-attachments/assets/62cdde84-3fb4-443c-bb1c-37f5ff2ff5ff" />