### PR TITLE
Frontend treebeard filter

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -121,6 +121,7 @@ export default function App() {
                 initialEyes: null,
                 interestRating: null,
                 hasLog: null,
+                treebeard: null,
             },
         },
         sendRequest: (params) => {

--- a/frontend/src/GameReports.tsx
+++ b/frontend/src/GameReports.tsx
@@ -244,7 +244,19 @@ export default function GameReports({
         },
         { key: "Mordor" },
         { key: "Aragorn" },
-        { key: "Treebeard" },
+        {
+            key: "Treebeard",
+            width: 150,
+            filter: {
+                filterType: "boolean",
+                placeholder: "Treebeard",
+                current: filters.treebeard,
+                trueLabel: "Mustered",
+                falseLabel: "Not mustered",
+                appliedCount: isDefined(filters.treebeard) ? 1 : 0,
+                onChange: (treebeard) => setFilters({ ...filters, treebeard }),
+            },
+        },
         {
             key: "Initial Eyes",
             width: 150,

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -270,6 +270,7 @@ export type GameReportFilters = {
     initialEyes: InequalityFilter | null;
     interestRating: InequalityFilter | null;
     hasLog: boolean | null;
+    treebeard: boolean | null;
 };
 
 export type GameReportParams = {


### PR DESCRIPTION
Nothing unexpected came up, so following your #298 comment will merge this! If you want a change to the options text at all though (like "yes"/"no" instead of "mustered"/"not mustered" or something like that) let me know and I'll adjust 👍 

| Initial | Open menu | "Mustered" applied | "Not mustered" applied |
| - | - | - | - |
| <img width="165" height="73" alt="image" src="https://github.com/user-attachments/assets/97dfc30a-9594-4199-8238-e0e36e72f355" /> | <img width="171" height="131" alt="image" src="https://github.com/user-attachments/assets/ebfe4347-7154-48b7-911c-b63038efe591" /> | <img width="169" height="107" alt="image" src="https://github.com/user-attachments/assets/e1b70a37-c76c-424e-bc7b-086c7d9f4d17" /> | <img width="161" height="80" alt="image" src="https://github.com/user-attachments/assets/015ac305-ba2d-4441-ae0c-791d711d56d0" /> |
