### PR TITLE
Frontend victory type filter

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -114,6 +114,7 @@ export default function App() {
                 winners: [],
                 losers: [],
                 leagues: [],
+                victory: [],
                 turns: null,
                 tokens: null,
                 dwarvenRings: null,

--- a/frontend/src/GameReports.tsx
+++ b/frontend/src/GameReports.tsx
@@ -10,7 +10,13 @@ import ModalDialog from "@mui/joy/ModalDialog";
 import Tooltip from "@mui/joy/Tooltip";
 import freeIconPath from "./assets/ring-emoji.png";
 import shadowIconPath from "./assets/volcano-emoji.png";
-import { ErrorMessage, GAME_LIMITS, leagues } from "./constants";
+import {
+    ErrorMessage,
+    GAME_LIMITS,
+    leagues,
+    sides,
+    victoryTypes,
+} from "./constants";
 import useMediaQuery from "./hooks/useMediaQuery";
 import { RefreshRequest } from "./hooks/useRequestState";
 import {
@@ -138,6 +144,7 @@ export default function GameReports({
     const colHeaders: (
         | ColHeaderData<MenuOption<number>>
         | ColHeaderData<MenuOption<string>>
+        | ColHeaderData<MenuOption<[Side, Victory]>>
     )[] = [
         { key: "Timestamp" },
         {
@@ -182,7 +189,28 @@ export default function GameReports({
             },
         },
         { key: "Game Type" },
-        { key: "Victory Type" },
+        {
+            key: "Victory Type",
+            width: 170,
+            filter: {
+                filterType: "autocomplete",
+                placeholder: "Select type",
+                loading: false,
+                options: sides.flatMap((side) =>
+                    victoryTypes.map(
+                        (victory): { id: [Side, Victory]; label: string } => ({
+                            id: [side, victory],
+                            label: toVictoryTypeLabel(side, victory),
+                        })
+                    )
+                ),
+                current: filters.victory,
+                appliedCount: filters.victory.length,
+                listboxStyle: { fontSize: "12px" },
+                onChange: (values) =>
+                    setFilters({ ...filters, victory: values }),
+            },
+        },
         { key: "Competition Type" },
         {
             key: "League",
@@ -549,6 +577,7 @@ export function serializeReportsParams(params: GameReportParams) {
             losers: toFilterParam(params.filters.losers),
             players: toFilterParam(params.filters.players),
             leagues: toFilterParam(params.filters.leagues),
+            victory: toFilterParam(params.filters.victory),
         }),
     };
 }
@@ -640,6 +669,16 @@ function isGameTypeExpansion(expansion: Expansion) {
     return ["KoME", "WoME", "LoME"].includes(expansion);
 }
 
+function toVictoryTypeLabel(side: Side, victory: Victory): string {
+    return `${side} ${
+        side === "Shadow" && victory === "Ring"
+            ? "Corruption"
+            : victory === "Concession"
+            ? "via Concession"
+            : victory
+    }`;
+}
+
 function summarizeVictoryType(side: Side, victory: Victory) {
     return (
         <Box
@@ -651,13 +690,7 @@ function summarizeVictoryType(side: Side, victory: Victory) {
                 padding: "3px 8px",
             }}
         >
-            {`${side} ${
-                side === "Shadow" && victory === "Ring"
-                    ? "Corruption"
-                    : victory === "Concession"
-                    ? "via Concession"
-                    : victory
-            }`}
+            {toVictoryTypeLabel(side, victory)}
         </Box>
     );
 }

--- a/frontend/src/GameReports.tsx
+++ b/frontend/src/GameReports.tsx
@@ -113,7 +113,8 @@ export default function GameReports({
         isAdmin ? { key: "Edit", width: 58 } : null,
     ].filter(isDefined);
 
-    const switchHeaders: (CornerHeaderData & ColHeaderData)[] = [
+    const switchHeaders: (CornerHeaderData<MenuOption<number>> &
+        ColHeaderData<MenuOption<number>>)[] = [
         { key: "No.", width: 50 },
         {
             key: "Pairing",
@@ -125,7 +126,7 @@ export default function GameReports({
                 options: playerOptions,
                 current: filters.pairing,
                 appliedCount: isPairingFilterValid ? filters.pairing.length : 0,
-                onChange: (values: MenuOption<number>[]) =>
+                onChange: (values) =>
                     setFilters({ ...filters, pairing: values }),
                 errorMessage: isPairingFilterValid
                     ? undefined
@@ -134,7 +135,10 @@ export default function GameReports({
         },
     ];
 
-    const colHeaders: ColHeaderData[] = [
+    const colHeaders: (
+        | ColHeaderData<MenuOption<number>>
+        | ColHeaderData<MenuOption<string>>
+    )[] = [
         { key: "Timestamp" },
         {
             key: "Turn",
@@ -159,7 +163,7 @@ export default function GameReports({
                 options: playerOptions,
                 current: filters.winners,
                 appliedCount: filters.winners.length,
-                onChange: (values: MenuOption<number>[]) =>
+                onChange: (values) =>
                     setFilters({ ...filters, winners: values }),
             },
         },
@@ -173,7 +177,7 @@ export default function GameReports({
                 options: playerOptions,
                 current: filters.losers,
                 appliedCount: filters.losers.length,
-                onChange: (values: MenuOption<number>[]) =>
+                onChange: (values) =>
                     setFilters({ ...filters, losers: values }),
             },
         },
@@ -195,7 +199,7 @@ export default function GameReports({
                 })),
                 current: filters.leagues,
                 appliedCount: filters.leagues.length,
-                onChange: (values: MenuOption<string>[]) => {
+                onChange: (values) => {
                     setFilters({ ...filters, leagues: values });
                 },
             },

--- a/frontend/src/Table/AutocompleteFilter.tsx
+++ b/frontend/src/Table/AutocompleteFilter.tsx
@@ -3,6 +3,7 @@ import MaterialAutocomplete from "@mui/joy/Autocomplete";
 import Box from "@mui/joy/Box";
 import FormControl from "@mui/joy/FormControl";
 import FormHelperText from "@mui/joy/FormHelperText";
+import { hasKey } from "../utils";
 import { FILTER_ERROR_HEIGHT, TABLE_FILTER_HEIGHT } from "./constants";
 import { FilterContainer } from "./styledComponents";
 import { AutocompleteProps, Option } from "./types";
@@ -16,6 +17,7 @@ export default function AutocompleteFilter<O extends Option>({
     errorMessage,
     allOption,
     emptyOption,
+    listboxStyle,
     onChange,
 }: AutocompleteProps<O> & { width: number }) {
     const [isFocused, setIsFocused] = useState(false);
@@ -104,6 +106,7 @@ export default function AutocompleteFilter<O extends Option>({
                         isOptionEqualToValue={(...args) =>
                             isOptionEqual(...args)
                         }
+                        slotProps={{ listbox: { sx: listboxStyle } }}
                         sx={{
                             background: "white",
                             fontSize: "inherit",
@@ -132,5 +135,20 @@ export default function AutocompleteFilter<O extends Option>({
 function isOptionEqual(a: Option, b: Option) {
     return typeof a === "string" || typeof b === "string"
         ? a === b
+        : Array.isArray(a.id) && Array.isArray(b.id)
+        ? areArraysShallowlyEqual(a.id, b.id)
+        : typeof a.id === "object" && typeof b.id === "object"
+        ? areObjectsShallowlyEqual(a.id, b.id)
         : a.id === b.id;
+}
+
+function areArraysShallowlyEqual(a: unknown[], b: unknown[]): boolean {
+    return a.every((el, i) => el === b[i]) && b.every((el, i) => el === a[i]);
+}
+
+function areObjectsShallowlyEqual(a: object | null, b: object | null): boolean {
+    return a === null || b === null
+        ? a === b
+        : Object.entries(a).every(([k, v]) => hasKey(b, k) && b[k] === v) &&
+              Object.entries(b).every(([k, v]) => hasKey(a, k) && a[k] === v);
 }

--- a/frontend/src/Table/types.tsx
+++ b/frontend/src/Table/types.tsx
@@ -19,6 +19,7 @@ export interface AutocompleteProps<Opt extends Option>
     loading: boolean;
     allOption?: Opt;
     emptyOption?: Opt;
+    listboxStyle?: CSSProperties;
     onChange: (value: Opt[]) => void;
 }
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -263,6 +263,7 @@ export type GameReportFilters = {
     winners: MenuOption<number>[];
     losers: MenuOption<number>[];
     leagues: MenuOption<string>[];
+    victory: MenuOption<[Side, Victory]>[];
     turns: InequalityFilter | null;
     tokens: InequalityFilter | null;
     dwarvenRings: InequalityFilter | null;

--- a/frontend/src/utils.tsx
+++ b/frontend/src/utils.tsx
@@ -222,3 +222,10 @@ export function sum(numbers: number[]) {
 export function fallback<T>(value: T, fallback: T) {
     return isDefined(value) ? value : fallback;
 }
+
+export function hasKey<K extends PropertyKey>(
+    obj: object,
+    key: K
+): obj is Record<K, unknown> {
+    return key in obj;
+}


### PR DESCRIPTION
Victory type filter! There are two commits to separate out some type cleanup from the new filter. There's a type in one of the autocomplete filter params that's not being inferred properly, which affected all the prior autocomplete filters too, but hadn't got around to fixing it til now.

| Initial | Menu open | Selections in progress | Filters applied |
| - | - | - | - |
| <img width="183" height="87" alt="image" src="https://github.com/user-attachments/assets/a420a41e-b512-4e46-a96c-5f8c4251b467" /> | <img width="200" height="264" alt="image" src="https://github.com/user-attachments/assets/2cc8393f-b7cb-48b2-b661-2c92a0c725ea" /> | <img width="204" height="310" alt="image" src="https://github.com/user-attachments/assets/e1132afa-af25-4b9f-83ae-22f158b0872e" /> | <img width="197" height="130" alt="image" src="https://github.com/user-attachments/assets/20815f51-0922-4ba5-b1a2-1241193a59c8" /> |
