### PR TITLE
Relabel "Ring" victory kind filter option to "Ring/Corruption"

### DIFF
--- a/frontend/src/GameReports.tsx
+++ b/frontend/src/GameReports.tsx
@@ -209,7 +209,10 @@ export default function GameReports({
                 loading: false,
                 options: [
                     ...sides.map((s) => ({ id: s, label: s })),
-                    ...victoryTypes.map((v) => ({ id: v, label: v })),
+                    ...victoryTypes.map((v) => ({
+                        id: v,
+                        label: toVictoryKindLabel(v),
+                    })),
                     ...sides.flatMap((s) =>
                         victoryTypes.map(
                             (v): { id: [Side, Victory]; label: string } => ({
@@ -764,6 +767,16 @@ function summarizeGameType(expansions: Expansion[]) {
 
 function isGameTypeExpansion(expansion: Expansion) {
     return ["KoME", "WoME", "LoME"].includes(expansion);
+}
+
+function toVictoryKindLabel(victory: Victory): string {
+    switch (victory) {
+        case "Ring":
+            return "Ring/Corruption";
+        case "Military":
+        case "Concession":
+            return victory;
+    }
 }
 
 function toVictoryTypeLabel(side: Side, victory: Victory): string {


### PR DESCRIPTION
Looking at this with fresh eyes after deploying and the "Ring" option feels potentially confusing. The option currently labeled "Ring" in the victory type filter is meant to encompass any ring-type victory, but might be confused to only represent a free ring victory.

| Old | New |
| - | - |
| <img width="187" height="166" alt="image" src="https://github.com/user-attachments/assets/ec7e6b92-76e1-44e8-8672-39affa9a3570" /> | <img width="204" height="165" alt="image" src="https://github.com/user-attachments/assets/9ea80d69-740d-47d4-ad65-caf927ac9ea0" /> |