### PR TITLE
Align table filters in firefox

### DIFF
--- a/frontend/src/components/Table/FilterBar.tsx
+++ b/frontend/src/components/Table/FilterBar.tsx
@@ -79,7 +79,7 @@ export default function FilterBar<
             })}
 
             {colHeaders.map(({ key, filter, width = 0, style = {} }) => (
-                <ColumnFilterSlot key={key} sx={style}>
+                <ColumnFilterSlot key={key} sx={{ height, ...style }}>
                     <Filter filter={filter} width={width} />
                 </ColumnFilterSlot>
             ))}


### PR DESCRIPTION
Resolves #307 

The browser difference is mildly interesting. In Chrome, if a table header cell computes it's height based on another table header cell rather than being given a height style explicitly, a child of that cell set to `height: 100%` will also expand to the computed height. In Firefox, a child given `height: 100%` doesn't expand to the computed height, and just stays at its own natural height. Tiny detail and not what I expected 🤷‍♀️ 