### PR TITLE
Import global CSS file

### DIFF
--- a/frontend/src/components/App.tsx
+++ b/frontend/src/components/App.tsx
@@ -33,6 +33,7 @@ import {
     BelowLarge,
     BelowSmall,
 } from "../styles/breakpoints";
+import "../styles/index.css";
 import sizes from "../styles/sizes";
 import {
     GameReportParams,


### PR DESCRIPTION
This was the problem - I added some styling to a global CSS file, but the CSS file wasn't explicitly imported into the app code.

What I don't understand is how I got the false positive in my dev environment?? It shouldn't have worked, but it did. I think it's something to do with webpack dev server, but I didn't have time to dig all the way into it.

Going to merge this and bring back the reverted commit!