### PR TITLE
Position table loading overlay without regard to scroll position

### DIFF
--- a/frontend/src/components/LoadingOverlay.tsx
+++ b/frontend/src/components/LoadingOverlay.tsx
@@ -1,24 +1,23 @@
-import React, { CSSProperties } from "react";
+import React from "react";
 import Box from "@mui/joy/Box";
 import CircularProgress from "@mui/joy/CircularProgress";
 
 interface Props {
-    overlayStyle?: CSSProperties;
+    bounds?: DOMRect;
 }
 
-export default function LoadingOverlay({ overlayStyle = {} }: Props) {
+export default function LoadingOverlay({ bounds }: Props) {
     return (
         <Box
             sx={{
-                position: "absolute",
+                position: bounds ? "fixed" : "absolute",
                 zIndex: 20,
-                width: "100%",
-                height: "100%",
+                width: bounds?.width || "100%",
+                height: bounds?.height || "100%",
                 display: "flex",
                 justifyContent: "center",
                 alignItems: "center",
                 background: "rgba(0 0 0 / 40%)",
-                ...overlayStyle,
             }}
         >
             <CircularProgress />

--- a/frontend/src/components/TableLayout.tsx
+++ b/frontend/src/components/TableLayout.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from "react";
+import React, { ReactNode, useRef } from "react";
 import Box from "@mui/joy/Box";
 import Button from "@mui/joy/Button";
 import Drawer from "@mui/joy/Drawer";
@@ -41,6 +41,8 @@ export default function TableLayout({
     tableStyle = {},
     settingsProps,
 }: Props) {
+    const tableContainerRef = useRef<HTMLDivElement>(null);
+
     return (
         <Box
             sx={{
@@ -105,6 +107,7 @@ export default function TableLayout({
             {error && <ErrorDisplay message={error} sx={{ pb: 2 }} />}
 
             <Box
+                ref={tableContainerRef}
                 sx={{
                     overflow: loading ? "hidden" : "auto",
                     boxShadow: "lg",
@@ -112,7 +115,11 @@ export default function TableLayout({
                     position: "relative",
                 }}
             >
-                {loading && <LoadingOverlay />}
+                {loading && (
+                    <LoadingOverlay
+                        bounds={tableContainerRef.current?.getBoundingClientRect()}
+                    />
+                )}
 
                 {/* TODO: always pass in custom Table component, then remove this `or` handling */}
                 {table || (


### PR DESCRIPTION
Resolves #295 

For reference, to reproduce bug in prod: scroll over in the game reports table and then click the "refresh" button