### PR TITLE
Make new league year available one month in advance

### DIFF
--- a/frontend/src/components/App.tsx
+++ b/frontend/src/components/App.tsx
@@ -60,6 +60,8 @@ const routesData = [
 
 const PAGE_LIMIT = 100;
 
+const activeLeagueYear = oneMonthFromNow().getFullYear();
+
 export default function App() {
     const [
         refreshUserInfo,
@@ -91,7 +93,7 @@ export default function App() {
         initialParams: {
             league: "GeneralLeague",
             tier: "Tier1",
-            year: new Date().getFullYear(),
+            year: activeLeagueYear,
         },
         sendRequest: (params) =>
             axios.get(`${API_BASE_URL}/leagueStats`, { params }),
@@ -238,6 +240,7 @@ export default function App() {
                             path="/leagues"
                             element={
                                 <Leagues
+                                    activeYear={activeLeagueYear}
                                     stats={leagueStats}
                                     playerNames={playerNames}
                                     loading={loadingLeague}
@@ -670,4 +673,11 @@ function Subtitle({ children }: SubtitleProps) {
             {children}
         </Typography>
     );
+}
+
+function oneMonthFromNow() {
+    const date = new Date();
+    const thisMonth = date.getMonth();
+    date.setMonth(thisMonth + 1);
+    return date;
 }

--- a/frontend/src/components/Leagues/PlayerForm.tsx
+++ b/frontend/src/components/Leagues/PlayerForm.tsx
@@ -1,5 +1,6 @@
 import axios from "axios";
 import React from "react";
+import Alert from "@mui/joy/Alert";
 import Box from "@mui/joy/Box";
 import { ErrorMessage } from "../../constants";
 import { API_BASE_URL } from "../../env";
@@ -85,6 +86,8 @@ export default function PlayerForm({
                 },
             ]}
         >
+            <YearBoundaryWarning selectedYear={formData.year.value} />
+
             <AutoPopulatedField
                 label="League:"
                 value={getLeagueLabel(formData.league.value)}
@@ -143,4 +146,21 @@ function AutoPopulatedField({ label, value }: AutoPopulatedFieldProps) {
             </Box>
         </Box>
     );
+}
+
+function YearBoundaryWarning(props: { selectedYear: number }) {
+    const { selectedYear } = props;
+
+    const now = new Date();
+    const currentYear = now.getFullYear();
+    const currentMonth = now.getMonth() + 1;
+
+    if (currentMonth === 12 && selectedYear <= currentYear) {
+        return (
+            <Alert color="warning" sx={{ textAlign: "center" }}>
+                {`It's almost ${currentYear + 1}. Are you in the right year?`}
+            </Alert>
+        );
+    }
+    return <></>;
 }

--- a/frontend/src/components/Leagues/index.tsx
+++ b/frontend/src/components/Leagues/index.tsx
@@ -30,6 +30,7 @@ import PlayerForm from "./PlayerForm";
 import { LeagueSelector, SubLeagueSelector } from "./styledComponents";
 
 interface Props {
+    activeYear: number;
     stats: LeagueStats;
     playerNames: string[];
     loading: boolean;
@@ -42,6 +43,7 @@ interface Props {
 }
 
 export default function Leagues({
+    activeYear,
     stats,
     playerNames,
     loading,
@@ -54,10 +56,7 @@ export default function Leagues({
 }: Props) {
     const [leaguePlayerFormOpen, setLeaguePlayerFormOpen] = useState(false);
 
-    const availableYears = range(
-        LEAGUE_START_YEAR,
-        new Date().getFullYear() + 1
-    );
+    const availableYears = range(LEAGUE_START_YEAR, activeYear + 1);
 
     return (
         <PageContainer>
@@ -80,7 +79,7 @@ export default function Leagues({
 
             <ButtonSelector
                 current={params.year}
-                options={availableYears.reverse()}
+                options={availableYears}
                 setCurrent={(year) =>
                     setParams((params) => ({ ...params, year }))
                 }
@@ -135,6 +134,7 @@ export default function Leagues({
                 refresh={refresh}
                 table={
                     <LeagueTable
+                        year={params.year}
                         stats={stats}
                         loading={loading}
                         isAdmin={isAdmin}
@@ -149,6 +149,7 @@ export default function Leagues({
 }
 
 interface LeagueTableProps {
+    year: number;
     stats: LeagueStats;
     loading: boolean;
     isAdmin: boolean;
@@ -156,6 +157,7 @@ interface LeagueTableProps {
 }
 
 function LeagueTable({
+    year,
     stats,
     loading,
     isAdmin,
@@ -177,7 +179,9 @@ function LeagueTable({
                     content: isAdmin ? (
                         <IconButton
                             size="sm"
-                            disabled={loading}
+                            disabled={
+                                loading || year < new Date().getFullYear()
+                            }
                             onClick={openLeaguePlayerForm}
                             variant="solid"
                             color="primary"


### PR DESCRIPTION
- Make each league year available 1 month in advance
- Make the default selected league year the latest available year
- If someone is adding a league player in December of the current year, display a warning to double check what year they're in
- Disable the "add player" button in historical years (so for 2025, the "+" button will become disabled in a few days)

| Year selection | When you click "+" in 2025 | When you click "+" in 2026 |
| - | - | - |
| <img width="207" height="173" alt="image" src="https://github.com/user-attachments/assets/5261addb-2734-4eb9-92a8-fbe22f417b4e" /> | <img width="347" height="439" alt="image" src="https://github.com/user-attachments/assets/049cc4ea-4021-4eaa-afde-ec22a74fb42f" /> | <img width="325" height="347" alt="image" src="https://github.com/user-attachments/assets/1b56e21a-9a7a-4ad5-99c0-c3c49f31a836" /> |