### PR TITLE
Order game report form strongholds

### DIFF
--- a/frontend/src/components/GameReportForm/index.tsx
+++ b/frontend/src/components/GameReportForm/index.tsx
@@ -32,6 +32,7 @@ import {
     GameFormData,
     GameReportPayload,
     ProcessedGameReport,
+    SameElements,
     ServerErrorBody,
     ServerValidationError,
     Stronghold,
@@ -745,8 +746,8 @@ function validationErrorToMessage(
     }
 }
 
-function orderStrongholds(strongholds: Stronghold[]) {
-    const gameFormOrder: Stronghold[] = [
+function orderStrongholds(shs: Stronghold[]) {
+    const gameFormOrder = [
         "MinasTirith",
         "Pelargir",
         "DolAmroth",
@@ -772,11 +773,16 @@ function orderStrongholds(strongholds: Stronghold[]) {
         "Umbar",
         "FarHarad",
         "SouthRhun",
-    ];
+    ] as const;
+
+    gameFormOrder satisfies SameElements<
+        typeof gameFormOrder,
+        typeof strongholds
+    >;
 
     const indices = new Map(gameFormOrder.map((v, i) => [v, i]));
 
-    return [...strongholds].sort(
-        (a, b) => (indices.get(a) ?? 0) - (indices.get(b) ?? 0)
+    return [...shs].sort(
+        (a, b) => (indices.get(a) ?? 0) - (indices.get(b) ?? 0),
     );
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -250,6 +250,17 @@ export type ValidLeaguePlayerFormData = {
 
 export type ValueOf<T> = T[keyof T];
 
+export type SameElements<
+    T extends readonly string[],
+    U extends readonly string[],
+> = T["length"] extends U["length"]
+    ? Exclude<U[number], T[number]> extends never
+        ? Exclude<T[number], U[number]> extends never
+            ? T
+            : never
+        : never
+    : never;
+
 export type NullFilter = "NullFilter";
 
 export type ApiInequalityOperator = "GT" | "LT" | "EQ";


### PR DESCRIPTION
Resolves #323 and #302 (unless we want to keep an issue open for future color coding? In which case I'll leave #302 open)

I decided against sharing the sort order with badges in historical game reports, because the badge layout has a really specific rhyme and reason that doesn't need to lock in the order of the game form's buttons with it.

I also decided against just reordering the root constant, because then it would be kind of secret/undocumented that we're relying on that list to stay ordered. So this is what I landed on.