### PR TITLE
Force game report form autocomplete to blur

### DIFF
--- a/frontend/src/components/Autocomplete.tsx
+++ b/frontend/src/components/Autocomplete.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useEffect, useState } from "react";
+import React, { ReactNode, useEffect, useRef, useState } from "react";
 import Alert from "@mui/joy/Alert";
 import Box from "@mui/joy/Box";
 import MaterialAutocomplete from "@mui/joy/Autocomplete";
@@ -32,6 +32,8 @@ export default function Autocomplete<O extends string | MenuOption<unknown>>({
     const [displayedAlertText, setDisplayedAlertText] =
         useState<ReactNode>(null);
 
+    const inputRef = useRef<HTMLInputElement>(null);
+
     useEffect(
         function clearAlertText() {
             if (!alertText && displayedAlertText) {
@@ -64,6 +66,7 @@ export default function Autocomplete<O extends string | MenuOption<unknown>>({
                 }
                 value={current}
                 placeholder={placeholder}
+                slotProps={{ input: { ref: inputRef } }}
                 onInputChange={(_, value) => {
                     onInputValueChange(value);
                     setLocalInputValue(value);
@@ -81,6 +84,17 @@ export default function Autocomplete<O extends string | MenuOption<unknown>>({
                     validate();
                     setDisplayedAlertText(alertText);
                     if (!current) setLocalInputValue("");
+
+                    /**
+                     * force a manual blur due to:
+                     * https://github.com/mui/material-ui/issues/47661
+                     */
+                    if (
+                        inputRef.current &&
+                        document.activeElement === inputRef.current
+                    ) {
+                        inputRef.current.blur();
+                    }
                 }}
                 disabled={loading}
                 startDecorator={


### PR DESCRIPTION
Resolves #321 

The MUI component's `onBlur` handler does fire when the browser window is left, even though the inner input doesn't actually blur. So we can just force a manual blur ourselves in the `onBlur` handler.

The autocomplete filter component used by the game reports page is affected too, so a better fix here would be to put the MUI autocomplete in a custom wrapper that always injects the manual blur handling, and use that wrapped version everywhere. But doesn't need to hold up the main bug fix.