### PR TITLE
Make prettier a local dependency and add helper scripts

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -26,6 +26,7 @@
                 "css-loader": "^7.1.2",
                 "html-webpack-plugin": "^5.6.0",
                 "mini-css-extract-plugin": "^2.9.0",
+                "prettier": "3.8.1",
                 "ts-loader": "^9.5.1",
                 "typescript": "^5.4.5",
                 "webpack": "^5.92.0",
@@ -4353,6 +4354,22 @@
             "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/prettier": {
+            "version": "3.8.1",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
+            "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "prettier": "bin/prettier.cjs"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/prettier/prettier?sponsor=1"
+            }
         },
         "node_modules/pretty-error": {
             "version": "4.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,9 @@
     "scripts": {
         "start": "NODE_ENV=development webpack serve --port 3000",
         "build": "NODE_ENV=production webpack",
-        "test": "echo \"Error: no test specified\" && exit 1"
+        "test": "echo \"Error: no test specified\" && exit 1",
+        "format": "prettier --write \"src/**/*.{ts,tsx}\"",
+        "format-check": "prettier --check \"src/**/*.{ts,tsx}\""
     },
     "author": "Bradley Sherman",
     "license": "ISC",
@@ -16,6 +18,7 @@
         "css-loader": "^7.1.2",
         "html-webpack-plugin": "^5.6.0",
         "mini-css-extract-plugin": "^2.9.0",
+        "prettier": "3.8.1",
         "ts-loader": "^9.5.1",
         "typescript": "^5.4.5",
         "webpack": "^5.92.0",


### PR DESCRIPTION
Wondering if the source of the formatting issues was that we don't have Prettier in the project as a dependency, so it was relying on my local VSC extension to get the version, instead of a fixed version. Almost all the issues look like `trailingComma` and ternary indentation, which I saw warnings about Prettier changing the defaults for at some point, but don't remember when. Either that, or I had a user-level override in my settings that's gone now 🤷‍♀️ 

Anyway, this adds Prettier as a dependency, a script for local auto-fixing, and a script that CI can use, when I set that up next.