### PR TITLE
Prevent browsers from using stale version of the client

### DIFF
--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,3 +1,3 @@
-trailingComma: 'es5'
-tabWidth: 2
-singleQuote: true
+trailingComma: "es5"
+tabWidth: 4
+singleQuote: false

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -10,7 +10,7 @@ module.exports = {
     entry: "./src/index.tsx",
     output: {
         path: path.resolve(__dirname + "/dist"),
-        filename: "bundle.js",
+        filename: "bundle.[contenthash].js",
     },
     target: "web",
     resolve: {
@@ -19,7 +19,7 @@ module.exports = {
                 __dirname,
                 "src",
                 "env",
-                isDev ? "dev.ts" : "prod.ts"
+                isDev ? "dev.ts" : "prod.ts",
             ),
         },
         extensions: [".ts", ".tsx", ".js", ".json"],
@@ -57,6 +57,8 @@ module.exports = {
             template: "./public/index.html",
             favicon: "./public/favicon.ico",
         }),
-        new MiniCssExtractPlugin(),
+        new MiniCssExtractPlugin({
+            filename: "[name].[contenthash].css",
+        }),
     ],
 };

--- a/infrastructure/lib/infrastructure-stack.ts
+++ b/infrastructure/lib/infrastructure-stack.ts
@@ -50,6 +50,21 @@ export class InfrastructureStack extends cdk.Stack {
                 ),
                 viewerProtocolPolicy:
                     cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+                responseHeadersPolicy: new cloudfront.ResponseHeadersPolicy(
+                    this,
+                    "ResponseHeadersPolicy",
+                    {
+                        customHeadersBehavior: {
+                            customHeaders: [
+                                {
+                                    header: "Cache-Control",
+                                    value: "no-cache",
+                                    override: true,
+                                },
+                            ],
+                        },
+                    }
+                ),
             },
             errorResponses: [
                 {


### PR DESCRIPTION
Draft, below are just WIP notes

Some work on #342:

- Based on reading https://webpack.js.org/guides/caching, I believe adding hashes to file names will prevent users from using stale versions of those files when starting new sessions. To be followed up with a UI flow for forcing a refresh during in-progress sessions.

- This can't be done (easily?) for `index.html`, but it's important that `index.html` not be cached, when it contains references to the now-changing bundle and CSS file names. I believe setting the [`Cache-Control` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Cache-Control) in responses to browsers will tell browsers to revalidate before relying on a cached file.
  - Wondering if this can just be the entire solution, and maybe we don't need the hashes in file names
    - https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Cache-Control: more reading on this here

- As a bonus, I think this finally answers the question I had in #315. Pretty sure the issue was a cached CSS file, which would explain why I encountered a dev/prod difference. I missed it at the time, but while I thought the issue was a missing CSS file import, the import actually was already present in `index.tsx`. So the fix I made didn't actually change anything; it just happened to cause or coincide with a cache update.