### PR TITLE
Add link to view game after submitting a report

### DIFF
--- a/frontend/src/components/GameReportForm/index.tsx
+++ b/frontend/src/components/GameReportForm/index.tsx
@@ -59,6 +59,7 @@ import useGameReportClearEffects from "../../hooks/useGameReportFormEffects";
 import FileUpload from "./FileUpload";
 import { CreateFormContainer, EditFormContainer } from "./styledComponents";
 import VictoryPoints from "./VictoryPoints";
+import { Link } from "react-router-dom";
 
 interface Props {
     report?: ProcessedGameReport;
@@ -146,6 +147,9 @@ function GameReportForm({
                 <ModalDialog>
                     <ModalClose />
                     <Typography mt={2}>{successMessage}</Typography>
+                    <Button component={Link} to="/game-reports">
+                        View Game
+                    </Button>
                 </ModalDialog>
             </Modal>
 


### PR DESCRIPTION
Resolves #281

Adds a link-button that navigates to the game reports page after submitting a game report. Optional future work: Highlight or blink the submitted game on the reports page after navigating.